### PR TITLE
Fixes #6: 修复了重复头文件  编译成功（虽然之前版本编译也不报错）

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,4 +122,7 @@ The following article offers plentiful user and administrator operation guides, 
 - [User Guide](docs/volclava%20%E5%AE%89%E8%A3%85%E5%8F%8A%E9%85%8D%E7%BD%AE%E6%96%87%E6%A1%A3.pdf)
 - [Administrator Guide](docs/volclava%20%E7%AE%A1%E7%90%86%E5%91%98%E6%89%8B%E5%86%8C.pdf)
 
+## Contact Us
+We welcome inquiries and collaboration opportunities regarding the advanced applications of our scheduler, such as developing new features and coming up with new product design. Let's jointly promote the growth of VolcLava. Please feel free to contact us at volclava@bytedance.com
+
 &copy; Copyright (C) 2021-2025 ByteBance Ltd. and/or its affiliates

--- a/lsf/intlib/listset.h
+++ b/lsf/intlib/listset.h
@@ -1,3 +1,6 @@
+#ifndef INCLUDE_LISTSET_H
+#define INCLUDE_LISTSET_H
+
 /* $Id: listset.h 397 2007-11-26 19:04:00Z mblack $
  * Copyright (C) 2007 Platform Computing Inc
  *
@@ -49,3 +52,5 @@ extern long  *listSetIteratorEnd(struct listSetIterator   *);
 extern long  *listSetIteratorGetNext(struct listSetIterator *);
 extern void  listSetIteratorDestroy(struct listSetIterator *);
 extern void  listSetIteratorDetach(struct listSetIterator *);
+
+#endif /* INCLUDE_LISTSET_H */

--- a/lsf/intlib/set.h
+++ b/lsf/intlib/set.h
@@ -1,3 +1,6 @@
+#ifndef INCLUDE_SET_H
+#define INCLUDE_SET_H
+
 /* $Id: set.h 397 2007-11-26 19:04:00Z mblack $
  * Copyright (C) 2007 Platform Computing Inc
  *
@@ -31,5 +34,7 @@ extern struct listSet *listSetDuplicate (struct listSet *);
 extern int listSetIn (int, struct listSet *);
 extern struct listSet *listSetInsert (int, struct listSet *);
 extern struct listSet *listSetSub(struct listSet *, struct listSet *);
+
+#endif /* INCLUDE_SET_H */
 
 

--- a/lsf/intlib/tokdefs.h
+++ b/lsf/intlib/tokdefs.h
@@ -1,3 +1,6 @@
+#ifndef INCLUDE_TOKDEFS_H
+#define INCLUDE_TOKDEFS_H
+
 /* $Id: tokdefs.h 397 2007-11-26 19:04:00Z mblack $
  * Copyright (C) 2007 Platform Computing Inc
  *
@@ -24,5 +27,7 @@ MAR,  APR,  MAY,  JUN, JUL, AUG, SEP, OCT, NOV, DEC, YY,  FY,
 WEEK, MONTH,QUARTER,    DAYS,    OR,  AND, LE,  GE,  EQ,  DOTS, 
 HH, MM, ESTRING,  NAME, RANGE, DATES, SZZZZ
 };
+
+#endif /* INCLUDE_TOKDEFS_H */
 
 

--- a/lsf/lib/lib.osux.h
+++ b/lsf/lib/lib.osux.h
@@ -1,3 +1,6 @@
+#ifndef INCLUDE_LIB_OSUX_H
+#define INCLUDE_LIB_OSUX_H
+
 /* $Id: lib.osux.h 397 2007-11-26 19:04:00Z mblack $
  * Copyright (C) 2007 Platform Computing Inc
  *
@@ -305,5 +308,7 @@ getEnvVar_( char* name,
 	return len;
     }
 }
+
+#endif /* INCLUDE_LIB_OSUX_H */
 
 

--- a/lsf/lib/lib.so.h
+++ b/lsf/lib/lib.so.h
@@ -1,3 +1,6 @@
+#ifndef INCLUDE_LIB_SO_H
+#define INCLUDE_LIB_SO_H
+
 /* $Id: lib.so.h 397 2007-11-26 19:04:00Z mblack $
  * Copyright (C) 2007 Platform Computing Inc
  *
@@ -23,3 +26,5 @@ typedef int SO_HANDLE_T;
 extern SO_HANDLE_T soOpen_(const char *libFileName);
 extern void soClose_(SO_HANDLE_T handle);
 extern void *soSym_(SO_HANDLE_T handle, const char *entryName);
+
+#endif /* INCLUDE_LIB_SO_H */

--- a/lsf/lim/lim.conf.h
+++ b/lsf/lim/lim.conf.h
@@ -1,3 +1,6 @@
+#ifndef INCLUDE_LIM_CONF_H
+#define INCLUDE_LIM_CONF_H
+
 /* $Id: lim.conf.h 397 2007-11-26 19:04:00Z mblack $
  * Copyright (C) 2007 Platform Computing Inc
  *
@@ -15,4 +18,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
  *
  */
+
+#endif /* INCLUDE_LIM_CONF_H */
 

--- a/lsf/lstools/load.c
+++ b/lsf/lstools/load.c
@@ -303,12 +303,13 @@ makeFields(struct hostLoad *host, char *loadval[], char **dispindex)
         else {
             if (LS_ISBUSYON(host->status, j)) {
                 strcpy(firstFmt, fmt[id].busy);
-                sprintf(fmtField, "%s%s",firstFmt, fmt[id].normFmt);
-                sprintf(tmpfield, fmtField, host->li[j] * fmt[id].scale);
-            }
-            else { 
+            } else { 
                 strcpy(firstFmt, fmt[id].ok);
-                sprintf(fmtField, "%s%s", firstFmt, fmt[id].normFmt);
+            }
+            sprintf(fmtField, "%s%s", firstFmt, fmt[id].normFmt);
+            if ((strcmp(fmt[id].name, "ut") == 0) && (host->li[j] * fmt[id].scale) > 100) {
+                sprintf(tmpfield, fmtField, 100);
+            } else {
                 sprintf(tmpfield, fmtField, host->li[j] * fmt[id].scale);
             }
             sp = stripSpaces(tmpfield);

--- a/lsf/lstools/lstools.h
+++ b/lsf/lstools/lstools.h
@@ -1,3 +1,6 @@
+#ifndef INCLUDE_LSTOOLS_H
+#define INCLUDE_LSTOOLS_H
+
 /* $Id: lstools.h 397 2007-11-26 19:04:00Z mblack $
  * Copyright (C) 2007 Platform Computing Inc
  *
@@ -17,3 +20,5 @@
  */
 
 #include <signal.h>
+
+#endif /* INCLUDE_LSTOOLS_H */


### PR DESCRIPTION
为仓库中以下头文件（`.h` 文件）添加了标准的包含守卫（`#ifndef`, `#endif`）指令：
* lsf/lim/lim.conf.h
* lsf/lstools/lstools.h
* lsf/intlib/set.h
* lsf/intlib/tokdefs.h
* lsf/intlib/listset.h
* lsf/lib/lib.so.h
* lsf/lib/lib.osux.h
<img width="427" alt="b04e6f1eaa840127f0b24a373e61cda" src="https://github.com/user-attachments/assets/971d3add-674b-46bd-935d-1d8989442f41" />
<img width="275" alt="75aaea54a19658e4380ba2ff87bad99" src="https://github.com/user-attachments/assets/f425fcec-2b96-4975-8310-fd1823177aec" />
