### PR TITLE
Update Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Everyone is welcomed to feed back via git issue.
 
 
 ## Support OS
-- CentOS 6/CentOS 7/CentOS 8  
+- CentOS 6/CentOS 7/CentOS 8
 - Redhat/Rocky 8
 - Ubuntu 20.04
 
@@ -100,7 +100,7 @@ cmp1-test           ok   0.0   0.0   0.0   0%   0.0   1     6   20G   10G   29G
 cmp2-test           ok   0.0   0.0   0.0   0%   0.0   1    24   45G   10G   30G
 
 [root@cmp2-test etc]# bhosts  ##check workload on hosts
-HOST_NAME          STATUS       JL/U    MAX  NJOBS    RUN  SSUSP  USUSP    RSV 
+HOST_NAME          STATUS       JL/U    MAX  NJOBS    RUN  SSUSP  USUSP    RSV
 cmp1-test          ok              -      4      0      0      0      0      0
 cmp2-test          ok              -      4      0      0      0      0      0
 master-test        ok              -      4      0      0      0      0      0
@@ -111,7 +111,7 @@ master-test        ok              -      4      0      0      0      0      0
 [root@master-test ~]# su - volclava
 [volclava@master-test ~]$ bsub sleep 100
 Job <1> is submitted to default queue <normal>.
-[volclava@master-test ~]$ bjobs 
+[volclava@master-test ~]$ bjobs
 JOBID   USER    STAT  QUEUE      FROM_HOST   EXEC_HOST   JOB_NAME   SUBMIT_TIME
 1       volclav PEND  normal     master-test             sleep 100  Nov 27 15:03
 ```
@@ -124,5 +124,16 @@ The following article offers plentiful user and administrator operation guides, 
 
 ## Contact Us
 We welcome inquiries and collaboration opportunities regarding the advanced applications of our scheduler, such as developing new features and coming up with new product design. Let's jointly promote the growth of VolcLava. Please feel free to contact us at volclava@bytedance.com
+
+# Compile
+# Building Notes
+
+If you are building this on a modern system where `rpc/xdr.h` is not found,
+you likely need the `libtirpc-devel` package. On RHEL9/Amazon Linux 2023,Rocky Linux 9, run:
+
+```bash
+sudo dnf install libtirpc libtirpc-devel
+./configure CPPFLAGS="-I/usr/include/tirpc" LDFLAGS="-ltirpc"
+
 
 &copy; Copyright (C) 2021-2025 ByteBance Ltd. and/or its affiliates


### PR DESCRIPTION
Update the README.md file to reflect the new xdr.h path. It is better to change the parameters of configure than the code as changing the code may break portability. 

We could eventually modified the configure.ac like this:

CPPFLAGS="$CPPFLAGS -I/usr/include/tirpc"
AC_CHECK_HEADERS([rpc/xdr.h])

Spago