### PR TITLE
Intlib compile errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,15 +125,4 @@ The following article offers plentiful user and administrator operation guides, 
 ## Contact Us
 We welcome inquiries and collaboration opportunities regarding the advanced applications of our scheduler, such as developing new features and coming up with new product design. Let's jointly promote the growth of VolcLava. Please feel free to contact us at volclava@bytedance.com
 
-# Compile
-# Building Notes
-
-If you are building this on a modern system where `rpc/xdr.h` is not found,
-you likely need the `libtirpc-devel` package. On RHEL9/Amazon Linux 2023,Rocky Linux 9, run:
-
-```bash
-sudo dnf install libtirpc libtirpc-devel
-./configure CPPFLAGS="-I/usr/include/tirpc" LDFLAGS="-ltirpc"
-
-
 &copy; Copyright (C) 2021-2025 ByteBance Ltd. and/or its affiliates

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Everyone is welcomed to feed back via git issue.
 
 
 ## Support OS
-- CentOS 6/CentOS 7/CentOS 8  
+- CentOS 6/CentOS 7/CentOS 8
 - Redhat/Rocky 8
 - Ubuntu 20.04
 
@@ -100,7 +100,7 @@ cmp1-test           ok   0.0   0.0   0.0   0%   0.0   1     6   20G   10G   29G
 cmp2-test           ok   0.0   0.0   0.0   0%   0.0   1    24   45G   10G   30G
 
 [root@cmp2-test etc]# bhosts  ##check workload on hosts
-HOST_NAME          STATUS       JL/U    MAX  NJOBS    RUN  SSUSP  USUSP    RSV 
+HOST_NAME          STATUS       JL/U    MAX  NJOBS    RUN  SSUSP  USUSP    RSV
 cmp1-test          ok              -      4      0      0      0      0      0
 cmp2-test          ok              -      4      0      0      0      0      0
 master-test        ok              -      4      0      0      0      0      0
@@ -111,7 +111,7 @@ master-test        ok              -      4      0      0      0      0      0
 [root@master-test ~]# su - volclava
 [volclava@master-test ~]$ bsub sleep 100
 Job <1> is submitted to default queue <normal>.
-[volclava@master-test ~]$ bjobs 
+[volclava@master-test ~]$ bjobs
 JOBID   USER    STAT  QUEUE      FROM_HOST   EXEC_HOST   JOB_NAME   SUBMIT_TIME
 1       volclav PEND  normal     master-test             sleep 100  Nov 27 15:03
 ```
@@ -124,5 +124,16 @@ The following article offers plentiful user and administrator operation guides, 
 
 ## Contact Us
 We welcome inquiries and collaboration opportunities regarding the advanced applications of our scheduler, such as developing new features and coming up with new product design. Let's jointly promote the growth of VolcLava. Please feel free to contact us at volclava@bytedance.com
+
+# Compile
+# Building Notes
+
+If you are building this on a modern system where `rpc/xdr.h` is not found,
+you likely need the `libtirpc-devel` package. On RHEL9/Amazon Linux 2023,Rocky Linux 9, run:
+
+```bash
+sudo dnf install libtirpc libtirpc-devel
+./configure CPPFLAGS="-I/usr/include/tirpc" LDFLAGS="-ltirpc"
+
 
 &copy; Copyright (C) 2021-2025 ByteBance Ltd. and/or its affiliates

--- a/lsf/intlib/bitset.h
+++ b/lsf/intlib/bitset.h
@@ -122,7 +122,7 @@ extern LS_BITSET_T *setCreate(const int, int (*getIndexByObject)(void *),
 		 void *(*getObjectByIndex)(int), char *);
 extern LS_BITSET_T *simpleSetCreate(const int, char *);
 extern int setDestroy(LS_BITSET_T *);
-extern LS_BITSET_T *setDup(LS_BITSET_T *);
+extern LS_BITSET_T *setDup(const LS_BITSET_T *);
 extern bool_t setTestValue(LS_BITSET_T *, const int);
 extern int setGetSize(LS_BITSET_T *);
 extern bool_t setIsMember(LS_BITSET_T *, void *);

--- a/lsf/intlib/resreq.c
+++ b/lsf/intlib/resreq.c
@@ -499,7 +499,17 @@ parseSelect(char *resReq, struct resVal *resVal, struct lsInfo *lsInfo, bool_t p
                 if (i == 0 ) {
                     sprintf(resReq2, "(%s)", expr);
 		} else {
-                    sprintf(resReq2, "%s||(%s)", resReq2, expr);
+                    char tmpbuf[4096];
+                    snprintf(tmpbuf, sizeof(tmpbuf), "%s||(%s)", resReq2, expr);
+                    /* We're assuming resReq2 has enough space — old code,
+                     * we trust it *for now*
+                     */
+                    if (strlen(tmpbuf) + 1 > strlen(resReq) + numXorExprs * 4 - 1) {
+                        // Bail out or truncate
+                        return PARSE_BAD_MEM;
+                    }
+                    strcpy(resReq2, tmpbuf);
+
 		}
 		freeResVal(&tmpResVal);
 		expr = strtok(NULL, ",");
@@ -834,9 +844,9 @@ validValue(char *value, struct lsInfo *lsInfo, int nentry)
 static int
 resToClassNew(char *resReq, struct resVal *resVal, struct lsInfo *lsInfo, int unitForLimits)
 {
-    int i, j, s, t, len, entry, hasFunction = FALSE, hasQuote;
+    int i, j, s, t, len, entry, hasQuote;
     char res[MAXLSFNAMELEN], val[MAXLSFNAMELEN];
-    char tmpbuf[MAXLSFNAMELEN*2];
+    char tmpbuf[MAXLSFNAMELEN * 7];
     char *sp, *op;
 
     len = strlen(resReq);
@@ -997,7 +1007,6 @@ resToClassNew(char *resReq, struct resVal *resVal, struct lsInfo *lsInfo, int un
                 default:
                     break;
             }
-            hasFunction = FALSE;
         } else {
             return (PARSE_BAD_EXP);
         }


### PR DESCRIPTION
Fix compiler errors in lsf/intlib. 

david@openlava-master ~/soft/volclava/master/lsf/intlib $ make
  CC       admin.o
  CC       cmdtime.o
  CC       jidx.o
  CC       lsftcl.o
  CC       resreq.o
  CC       bitset.o
  CC       conf.o
  CC       list.o
  CC       misc.o
  CC       userok.o
  CC       window.o
  CC       callex.o
  CC       daemon.o
  CC       listset.o
  CC       resourcecmd.o
  CC       testbitset.o
  CC       list2.o
  CC       link.o
  AR       liblsfint.a

Note that some changes may appear useless but those are made by emacs which is configured to remove trailing white spaces and useless white lines.

Spago
