### PR TITLE
Lim compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,15 +125,4 @@ The following article offers plentiful user and administrator operation guides, 
 ## Contact Us
 We welcome inquiries and collaboration opportunities regarding the advanced applications of our scheduler, such as developing new features and coming up with new product design. Let's jointly promote the growth of VolcLava. Please feel free to contact us at volclava@bytedance.com
 
-# Compile
-# Building Notes
-
-If you are building this on a modern system where `rpc/xdr.h` is not found,
-you likely need the `libtirpc-devel` package. On RHEL9/Amazon Linux 2023,Rocky Linux 9, run:
-
-```bash
-sudo dnf install libtirpc libtirpc-devel
-./configure CPPFLAGS="-I/usr/include/tirpc" LDFLAGS="-ltirpc"
-
-
 &copy; Copyright (C) 2021-2025 ByteBance Ltd. and/or its affiliates

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Everyone is welcomed to feed back via git issue.
 
 
 ## Support OS
-- CentOS 6/CentOS 7/CentOS 8  
+- CentOS 6/CentOS 7/CentOS 8
 - Redhat/Rocky 8
 - Ubuntu 20.04
 
@@ -100,7 +100,7 @@ cmp1-test           ok   0.0   0.0   0.0   0%   0.0   1     6   20G   10G   29G
 cmp2-test           ok   0.0   0.0   0.0   0%   0.0   1    24   45G   10G   30G
 
 [root@cmp2-test etc]# bhosts  ##check workload on hosts
-HOST_NAME          STATUS       JL/U    MAX  NJOBS    RUN  SSUSP  USUSP    RSV 
+HOST_NAME          STATUS       JL/U    MAX  NJOBS    RUN  SSUSP  USUSP    RSV
 cmp1-test          ok              -      4      0      0      0      0      0
 cmp2-test          ok              -      4      0      0      0      0      0
 master-test        ok              -      4      0      0      0      0      0
@@ -111,7 +111,7 @@ master-test        ok              -      4      0      0      0      0      0
 [root@master-test ~]# su - volclava
 [volclava@master-test ~]$ bsub sleep 100
 Job <1> is submitted to default queue <normal>.
-[volclava@master-test ~]$ bjobs 
+[volclava@master-test ~]$ bjobs
 JOBID   USER    STAT  QUEUE      FROM_HOST   EXEC_HOST   JOB_NAME   SUBMIT_TIME
 1       volclav PEND  normal     master-test             sleep 100  Nov 27 15:03
 ```
@@ -124,5 +124,16 @@ The following article offers plentiful user and administrator operation guides, 
 
 ## Contact Us
 We welcome inquiries and collaboration opportunities regarding the advanced applications of our scheduler, such as developing new features and coming up with new product design. Let's jointly promote the growth of VolcLava. Please feel free to contact us at volclava@bytedance.com
+
+# Compile
+# Building Notes
+
+If you are building this on a modern system where `rpc/xdr.h` is not found,
+you likely need the `libtirpc-devel` package. On RHEL9/Amazon Linux 2023,Rocky Linux 9, run:
+
+```bash
+sudo dnf install libtirpc libtirpc-devel
+./configure CPPFLAGS="-I/usr/include/tirpc" LDFLAGS="-ltirpc"
+
 
 &copy; Copyright (C) 2021-2025 ByteBance Ltd. and/or its affiliates

--- a/chkpnt/Makefile.am
+++ b/chkpnt/Makefile.am
@@ -1,7 +1,7 @@
 #
 # Copyright (C) openlava foundation
 #
-INCLUDES = -I../lsf
+AM_CPPFLAGS = -I../lsf
 
 sbin_PROGRAMS = echkpnt erestart
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,39 +1,11 @@
-#
-# volclava project
-#
-# Copyright (C) 2021-2025 Bytedance Ltd. and/or its affiliates
-# Copyright (C) 2011 David Bigagli
-#
-AC_INIT(volclava, 2.0)
-AC_CONFIG_HEADERS(config.h)
+# configure.ac for volclava — compatible and minimal
+AC_INIT([volclava], [2.0], [support@example.com])
+AC_CONFIG_HEADERS([config.h])
+AC_CONFIG_SRCDIR([lsf/Makefile.am])
 AC_PREFIX_DEFAULT([/opt/volclava-2.0])
 
-
-# Set some cluster configuration variables .
-AC_SUBST([volclavadmin], [volclava])
-AC_ARG_VAR([volclavaadmin], "")
-AC_SUBST([volclavacluster], [volclava])
-AC_ARG_VAR([volclavacluster], "")
-
-# Cygwin support
-AC_CANONICAL_SYSTEM
-case "${target_os}" in
-  *cygwin*)
-    AM_CONDITIONAL([CYGWIN], [true]) ;;
-  *)
-    AM_CONDITIONAL([CYGWIN], [false]) ;;
-esac
-
-# Initialize the automake
-AM_INIT_AUTOMAKE
-
-# Expirimental scheduling module
-AM_CONDITIONAL([SCHED_EXPERIMENTAL], [false])
-
-# Clean output if possible
-m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
-
-# Check for programs
+AM_INIT_AUTOMAKE([foreign subdir-objects])
+AM_SILENT_RULES([yes])
 AC_PROG_CC
 AC_PROG_INSTALL
 AC_PROG_RANLIB
@@ -42,70 +14,78 @@ AC_PROG_LEX
 AC_PROG_LN_S
 AC_PROG_MAKE_SET
 
-#AC_DEFINE(REL_DATE, "Jan 31 2012", "Set the release date.")
-
-# Force warnings on for gcc
-if test "x$ac_compiler_gnu" = xyes; then
-    CFLAGS="$CFLAGS -Wall -fPIC -Wno-error=format-security"
+# GCC warnings
+if test "$GCC" = "yes"; then
+  CFLAGS="$CFLAGS -Wall -fPIC -Wno-error=format-security"
 fi
 
-CFLAGS="$CFLAGS -I/usr/include/tirpc"
+# Optional build-time overrides
+AC_ARG_VAR([volclavaadmin], [volclava admin binary name])
+AC_ARG_VAR([volclavacluster], [volclava cluster name])
+AC_SUBST([volclavaadmin])
+AC_SUBST([volclavacluster])
 
-AC_CHECK_HEADERS([rpc/xdr.h], [], [AC_CHECK_HEADERS([tirpc/rpc/xdr.h], [CFLAGS="-I/usr/include/tirpc"], AC_MSG_ERROR([cannot build volclava without xdr])]))
-AC_SEARCH_LIBS([xdr_int], [rpc tirpc], [], [AC_MSG_ERROR([cannot build volclava without XDR])])
+# Add libtirpc headers
+CPPFLAGS="$CPPFLAGS -I/usr/include/tirpc"
 
-#AC_CHECK_HEADERS(ncurses.h,[cf_cv_ncurses_header="ncurses.h"])
-# Check for tcl, we try tcl and all 8.X versions
-AC_CHECK_HEADERS([tcl.h], [], [AC_CHECK_HEADERS([tcl/tcl.h], [], AC_MSG_ERROR([cannot build volclava without tcl])]))
+# Check for XDR headers and libtirpc
+AC_CHECK_HEADERS([rpc/xdr.h], [], [AC_MSG_ERROR([cannot build volclava: missing rpc/xdr.h])])
+AC_SEARCH_LIBS([xdrmem_create], [tirpc], [], [AC_MSG_ERROR([missing -ltirpc])])
+
+# Check for libnsl (NIS)
+AC_CHECK_LIB([nsl], [yp_get_default_domain], [LIBS="$LIBS -lnsl"], [AC_MSG_ERROR([missing libnsl])])
+
+# Check Tcl headers
+AC_CHECK_HEADERS([tcl.h], [], [
+  AC_CHECK_HEADERS([tcl/tcl.h], [], [AC_MSG_ERROR([missing tcl.h])])
+])
+
+# Tcl library search
 AC_CHECK_LIB([tcl], [Tcl_CreateInterp], [], [
- AC_CHECK_LIB([tcl8.6], [Tcl_CreateInterp], [], [
-    AC_CHECK_LIB([tcl8.5], [Tcl_CreateInterp], [], [
-        AC_CHECK_LIB([tcl8.4], [Tcl_CreateInterp], [], [
-            AC_CHECK_LIB([tcl8.3], [Tcl_CreateInterp], [], [
-                AC_CHECK_LIB([tcl8.2], [Tcl_CreateInterp], [], [
-                    AC_CHECK_LIB([tcl8.1], [Tcl_CreateInterp], [], [
-                        AC_CHECK_LIB([tcl8.0], [Tcl_CreateInterp], [], [
-                            AC_MSG_ERROR([cannot build volclava without tcl8.*])
-])])])])])])])])
+  for v in 8.6 8.5 8.4 8.3 8.2 8.1 8.0; do
+    AC_CHECK_LIB([tcl$v], [Tcl_CreateInterp], [LIBS="$LIBS -ltcl$v"; break])
+  done
+])
 
+# Output Makefiles
 AC_CONFIG_FILES([
-	Makefile                 \
-	config/Makefile          \
-	lsf/Makefile             \
-	lsf/intlib/Makefile      \
-	lsf/lib/Makefile         \
-	lsf/lim/Makefile         \
-	lsf/res/Makefile         \
-	lsf/pim/Makefile         \
-	lsf/lstools/Makefile     \
-	lsf/lsadm/Makefile       \
-	lsf/man/Makefile         \
-	lsf/man/man1/Makefile    \
-	lsf/man/man5/Makefile    \
-	lsf/man/man8/Makefile    \
-	lsbatch/Makefile         \
-	lsbatch/lib/Makefile     \
-	lsbatch/cmd/Makefile     \
-	lsbatch/bhist/Makefile   \
-	lsbatch/daemons/Makefile \
-	lsbatch/man1/Makefile    \
-	lsbatch/man5/Makefile    \
-	lsbatch/man8/Makefile    \
-	eauth/Makefile           \
-	scripts/Makefile         \
-	chkpnt/Makefile          \
-	config/lsf.conf          \
-	config/lsb.hosts         \
-	config/lsb.params        \
-	config/lsb.queues        \
-	config/lsb.users         \
-	config/lsf.cluster.volclava \
-	config/lsf.shared        \
-	config/lsf.task          \
-	config/volclava.csh      \
-	config/volclava          \
-	config/volclava.setup    \
-	config/volclava.sh]
-)
+  Makefile
+  config/Makefile
+  lsf/Makefile
+  lsf/intlib/Makefile
+  lsf/lib/Makefile
+  lsf/lim/Makefile
+  lsf/res/Makefile
+  lsf/pim/Makefile
+  lsf/lstools/Makefile
+  lsf/lsadm/Makefile
+  lsf/man/Makefile
+  lsf/man/man1/Makefile
+  lsf/man/man5/Makefile
+  lsf/man/man8/Makefile
+  lsbatch/Makefile
+  lsbatch/lib/Makefile
+  lsbatch/cmd/Makefile
+  lsbatch/bhist/Makefile
+  lsbatch/daemons/Makefile
+  lsbatch/man1/Makefile
+  lsbatch/man5/Makefile
+  lsbatch/man8/Makefile
+  eauth/Makefile
+  scripts/Makefile
+  chkpnt/Makefile
+  config/lsf.conf
+  config/lsb.hosts
+  config/lsb.params
+  config/lsb.queues
+  config/lsb.users
+  config/lsf.cluster.volclava
+  config/lsf.shared
+  config/lsf.task
+  config/volclava.csh
+  config/volclava
+  config/volclava.setup
+  config/volclava.sh
+])
 
 AC_OUTPUT

--- a/eauth/Makefile.am
+++ b/eauth/Makefile.am
@@ -1,7 +1,7 @@
 #
 # Copyright (C) openlava foundation
 #
-INCLUDES = -I$(top_srcdir)/lsf
+AM_CPPFLAGS = -I$(top_srcdir)/lsf
 
 sbin_PROGRAMS = eauth
 eauth_SOURCES = eauth.c

--- a/lsbatch/bhist/Makefile.am
+++ b/lsbatch/bhist/Makefile.am
@@ -1,7 +1,7 @@
 #
 # Copyright (C) openlava foundation
 #
-INCLUDES = -I$(top_srcdir)/lsf  -I$(top_srcdir)/lsf/lib \
+AM_CPPFLAGS = -I$(top_srcdir)/lsf  -I$(top_srcdir)/lsf/lib \
            -I$(top_srcdir)/lsbatch  -I$(top_srcdir)/lsbatch/lib -I./
 
 bin_PROGRAMS = bhist
@@ -12,6 +12,3 @@ bhist_LDADD = ../cmd/cmd.job.o \
 	../lib/liblsbatch.a \
 	../../lsf/lib/liblsf.a \
 	../../lsf/intlib/liblsfint.a -lm
-if !CYGWIN
-bhist_LDADD += -lnsl
-endif

--- a/lsbatch/cmd/Makefile.am
+++ b/lsbatch/cmd/Makefile.am
@@ -2,12 +2,12 @@
 # Copyright (C) 2021-2025 Bytedance Ltd. and/or its affiliates
 # Copyright (C) openlava foundation
 #
-INCLUDES = -I$(top_srcdir)/lsf  -I$(top_srcdir)/lsf/lib \
+AM_CPPFLAGS = -I$(top_srcdir)/lsf  -I$(top_srcdir)/lsf/lib \
            -I$(top_srcdir)/lsbatch  -I$(top_srcdir)/lsbatch/lib -I./
 
 bin_PROGRAMS = badmin bkill bparams brestart btop bbot bmgroup \
 bpeek brun busers bhosts bmig bqueues bsub bjobs bmod \
-brequeue bswitch 
+brequeue bswitch
 
 badmin_SOURCES = badmin.c cmd.bqc.c cmd.hist.c \
 	cmd.bhc.c cmd.misc.c cmd.job.c cmd.prt.c \
@@ -16,9 +16,6 @@ badmin_LDADD = ../../lsf/lsadm/startup.o \
 	../lib/liblsbatch.a \
 	../../lsf/lib/liblsf.a \
 	../../lsf/intlib/liblsfint.a -lm
-if !CYGWIN
-badmin_LDADD += -lnsl
-endif
 
 bkill_SOURCES = bkill.c cmd.sig.c cmd.jobid.c cmd.err.c
 bkill_LDADD = \
@@ -26,19 +23,11 @@ bkill_LDADD = \
 	../../lsf/lib/liblsf.a \
 	../../lsf/intlib/liblsfint.a  -lm
 
-if !CYGWIN
-bkill_LDADD += -lnsl
-endif
-
 bparams_SOURCES = bparams.c cmd.h
 bparams_LDADD =   \
 	../lib/liblsbatch.a \
 	../../lsf/lib/liblsf.a \
 	../../lsf/intlib/liblsfint.a  -lm
-if !CYGWIN
-bparams_LDADD += -lnsl
-endif
-
 
 brestart_SOURCES = brestart.c cmd.sub.c cmd.jobid.c \
 	cmd.err.c cmd.h
@@ -46,10 +35,6 @@ brestart_LDADD =   \
 	../lib/liblsbatch.a \
 	../../lsf/lib/liblsf.a \
 	../../lsf/intlib/liblsfint.a  -lm
-if !CYGWIN
-brestart_LDADD += -lnsl
-endif
-
 
 btop_SOURCES = btop.c cmd.move.c cmd.jobid.c cmd.misc.c \
 	 cmd.prt.c cmd.err.c cmd.h
@@ -57,10 +42,6 @@ btop_LDADD =  \
 	../lib/liblsbatch.a \
 	../../lsf/lib/liblsf.a \
 	../../lsf/intlib/liblsfint.a  -lm
-if !CYGWIN
-btop_LDADD += -lnsl
-endif
-
 
 bbot_SOURCES = bbot.c cmd.move.c cmd.jobid.c cmd.misc.c \
 	 cmd.prt.c cmd.err.c cmd.h
@@ -68,86 +49,54 @@ bbot_LDADD =   \
 	../lib/liblsbatch.a \
 	../../lsf/lib/liblsf.a \
 	../../lsf/intlib/liblsfint.a  -lm
-if !CYGWIN
-bbot_LDADD += -lnsl
-endif
-
 
 bmgroup_SOURCES = bmgroup.c cmd.misc.c cmd.h
 bmgroup_LDADD =   \
 	../lib/liblsbatch.a \
 	../../lsf/lib/liblsf.a \
 	../../lsf/intlib/liblsfint.a  -lm
-if !CYGWIN
-bmgroup_LDADD += -lnsl
-endif
-
 
 bpeek_SOURCES = bpeek.c cmd.err.c cmd.jobid.c cmd.misc.c cmd.prt.c cmd.h
 bpeek_LDADD =  \
 	../lib/liblsbatch.a \
 	../../lsf/lib/liblsf.a \
 	../../lsf/intlib/liblsfint.a  -lm
-if !CYGWIN
-bpeek_LDADD += -lnsl
-endif
-
 
 brun_SOURCES = brun.c cmd.jobid.c cmd.err.c cmd.h
 brun_LDADD =   \
 	../lib/liblsbatch.a \
 	../../lsf/lib/liblsf.a \
 	../../lsf/intlib/liblsfint.a  -lm
-if !CYGWIN
-brun_LDADD += -lnsl
-endif
-
 
 busers_SOURCES = busers.c cmd.misc.c
 busers_LDADD =  \
 	../lib/liblsbatch.a \
 	../../lsf/lib/liblsf.a \
 	../../lsf/intlib/liblsfint.a  -lm
-if !CYGWIN
-busers_LDADD += -lnsl
-endif
-
 
 bhosts_SOURCES = bhosts.c cmd.prt.c cmd.misc.c cmd.h
 bhosts_LDADD =  \
 	../lib/liblsbatch.a \
 	../../lsf/lib/liblsf.a \
 	../../lsf/intlib/liblsfint.a  -lm
-if !CYGWIN
-bhosts_LDADD += -lnsl
-endif
 
 bmig_SOURCES = bmig.c cmd.jobid.c cmd.err.c cmd.h
 bmig_LDADD =   \
 	../lib/liblsbatch.a \
 	../../lsf/lib/liblsf.a \
 	../../lsf/intlib/liblsfint.a  -lm
-if !CYGWIN
-bmig_LDADD += -lnsl
-endif
 
 bqueues_SOURCES = bqueues.c cmd.prt.c cmd.misc.c cmd.h
 bqueues_LDADD = \
 	../lib/liblsbatch.a \
 	../../lsf/lib/liblsf.a \
 	../../lsf/intlib/liblsfint.a  -lm
-if !CYGWIN
-bqueues_LDADD += -lnsl
-endif
 
 bsub_SOURCES = bsub.c cmd.sub.c cmd.jobid.c cmd.err.c cmd.h
 bsub_LDADD =   \
 	../lib/liblsbatch.a \
 	../../lsf/lib/liblsf.a \
 	../../lsf/intlib/liblsfint.a  -lm
-if !CYGWIN
-bsub_LDADD += -lnsl
-endif
 
 bjobs_SOURCES = bjobs.c cmd.prt.c cmd.err.c cmd.job.c \
 	cmd.jobid.c cmd.misc.c cmd.h cJSON.c cJSON.h
@@ -155,36 +104,24 @@ bjobs_LDADD =  \
 	../lib/liblsbatch.a \
 	../../lsf/lib/liblsf.a \
 	../../lsf/intlib/liblsfint.a  -lm
-if !CYGWIN
-bjobs_LDADD += -lnsl
-endif
 
 bmod_SOURCES = bmod.c cmd.sub.c cmd.jobid.c cmd.err.c cmd.h
 bmod_LDADD =  \
 	../lib/liblsbatch.a \
 	../../lsf/lib/liblsf.a \
 	../../lsf/intlib/liblsfint.a  -lm
-if !CYGWIN
-bmod_LDADD += -lnsl
-endif
 
 brequeue_SOURCES = brequeue.c cmd.jobid.c cmd.err.c cmd.h
 brequeue_LDADD =   \
 	../lib/liblsbatch.a \
 	../../lsf/lib/liblsf.a \
 	../../lsf/intlib/liblsfint.a  -lm
-if !CYGWIN
-brequeue_LDADD += -lnsl
-endif
 
 bswitch_SOURCES = bswitch.c cmd.jobid.c cmd.err.c cmd.h
 bswitch_LDADD =  \
 	../lib/liblsbatch.a \
 	../../lsf/lib/liblsf.a \
 	../../lsf/intlib/liblsfint.a  -lm
-if !CYGWIN
-bswitch_LDADD += -lnsl
-endif
 
 install-data-local:
 	cd "$(DESTDIR)$(bindir)" && ln -sf bkill bstop

--- a/lsbatch/daemons/Makefile.am
+++ b/lsbatch/daemons/Makefile.am
@@ -2,40 +2,28 @@
 # Copyright (C) 2021-2025 Bytedance Ltd. and/or its affiliates
 # Copyright (C) openlava foundation
 #
-INCLUDES = -I$(top_srcdir)/lsf  -I$(top_srcdir)/lsf/lib \
+AM_CPPFLAGS = -I$(top_srcdir)/lsf  -I$(top_srcdir)/lsf/lib \
            -I$(top_srcdir)/lsbatch  -I$(top_srcdir)/lsbatch/lib -I./
 
 sbin_PROGRAMS = mbatchd sbatchd
 mbatchd_SOURCES  = \
-mbd.comm.c mbd.host.c mbd.jgrp.c mbd.main.c mbd.proxy.c mbd.resource.c \
-mbd.dep.c mbd.init.c mbd.job.c mbd.misc.c mbd.queue.c mbd.serv.c \
-mbd.grp.c mbd.jarray.c mbd.log.c mbd.requeue.c mbd.window.c mbd.fairshare.c\
-elock.c misc.c mail.c daemons.c daemons.xdr.c \
-mbd.h daemonout.h daemons.h jgrp.h proxy.h mbd.profcnt.def mbd.fairshare.h 
-if SCHED_EXPERIMENTAL
-mbatchd_SOURCES += mbd.epolicy.c
-else
-mbatchd_SOURCES += mbd.policy.c
-endif
+mbd.policy.c mbd.comm.c mbd.host.c mbd.jgrp.c mbd.main.c mbd.proxy.c \
+mbd.resource.c mbd.dep.c mbd.init.c mbd.job.c mbd.misc.c mbd.queue.c \
+mbd.serv.c mbd.grp.c mbd.jarray.c mbd.log.c mbd.requeue.c mbd.window.c \
+mbd.fairshare.c elock.c misc.c mail.c daemons.c daemons.xdr.c \
+mbd.h daemonout.h daemons.h jgrp.h proxy.h mbd.profcnt.def mbd.fairshare.h
 
 mbatchd_LDADD = ../lib/liblsbatch.a \
                 ../../lsf/lib/liblsf.a \
                 ../../lsf/intlib/liblsfint.a -lm
-if !CYGWIN
-mbatchd_LDADD += -lnsl
-endif
-
 sbatchd_SOURCES = sbd.comm.c sbd.file.c sbd.job.c sbd.main.c \
                   sbd.misc.c sbd.policy.c sbd.serv.c sbd.sig.c sbd.xdr.c \
                   elock.c mail.c misc.c daemons.c daemons.xdr.c \
-                  sbd.h daemonout.h daemons.h 
+                  sbd.h daemonout.h daemons.h
 
 sbatchd_LDADD = ../lib/liblsbatch.a \
                 ../../lsf/lib/liblsf.a \
                 ../../lsf/intlib/liblsfint.a -lm
-if !CYGWIN
-sbatchd_LDADD += -lnsl
-endif
 
 etags :
 	etags *.[hc] ../*.h ../lib/*.[hc] ../../lsf/*.h \

--- a/lsbatch/lib/Makefile.am
+++ b/lsbatch/lib/Makefile.am
@@ -1,7 +1,7 @@
 #
 # Copyright (C) 2011 openlava foundation
 #
-INCLUDES = -I$(top_srcdir)/lsf -I$(top_srcdir)/lsf/lib \
+AM_CPPFLAGS = -I$(top_srcdir)/lsf -I$(top_srcdir)/lsf/lib \
            -I$(top_srcdir)/lsbatch -I./
 
 lib_LIBRARIES = liblsbatch.a

--- a/lsf/intlib/Makefile.am
+++ b/lsf/intlib/Makefile.am
@@ -2,7 +2,7 @@
 # Copyright (C) 2011 openlava foundation
 #
 
-INCLUDES = -I../
+AM_CPPFLAGS = -I../
 
 noinst_LIBRARIES = liblsfint.a
 

--- a/lsf/intlib/bitset.h
+++ b/lsf/intlib/bitset.h
@@ -122,7 +122,7 @@ extern LS_BITSET_T *setCreate(const int, int (*getIndexByObject)(void *),
 		 void *(*getObjectByIndex)(int), char *);
 extern LS_BITSET_T *simpleSetCreate(const int, char *);
 extern int setDestroy(LS_BITSET_T *);
-extern LS_BITSET_T *setDup(LS_BITSET_T *);
+extern LS_BITSET_T *setDup(const LS_BITSET_T *);
 extern bool_t setTestValue(LS_BITSET_T *, const int);
 extern int setGetSize(LS_BITSET_T *);
 extern bool_t setIsMember(LS_BITSET_T *, void *);

--- a/lsf/intlib/resreq.c
+++ b/lsf/intlib/resreq.c
@@ -499,7 +499,17 @@ parseSelect(char *resReq, struct resVal *resVal, struct lsInfo *lsInfo, bool_t p
                 if (i == 0 ) {
                     sprintf(resReq2, "(%s)", expr);
 		} else {
-                    sprintf(resReq2, "%s||(%s)", resReq2, expr);
+                    char tmpbuf[4096];
+                    snprintf(tmpbuf, sizeof(tmpbuf), "%s||(%s)", resReq2, expr);
+                    /* We're assuming resReq2 has enough space — old code,
+                     * we trust it *for now*
+                     */
+                    if (strlen(tmpbuf) + 1 > strlen(resReq) + numXorExprs * 4 - 1) {
+                        // Bail out or truncate
+                        return PARSE_BAD_MEM;
+                    }
+                    strcpy(resReq2, tmpbuf);
+
 		}
 		freeResVal(&tmpResVal);
 		expr = strtok(NULL, ",");
@@ -834,9 +844,9 @@ validValue(char *value, struct lsInfo *lsInfo, int nentry)
 static int
 resToClassNew(char *resReq, struct resVal *resVal, struct lsInfo *lsInfo, int unitForLimits)
 {
-    int i, j, s, t, len, entry, hasFunction = FALSE, hasQuote;
+    int i, j, s, t, len, entry, hasQuote;
     char res[MAXLSFNAMELEN], val[MAXLSFNAMELEN];
-    char tmpbuf[MAXLSFNAMELEN*2];
+    char tmpbuf[MAXLSFNAMELEN * 7];
     char *sp, *op;
 
     len = strlen(resReq);
@@ -997,7 +1007,6 @@ resToClassNew(char *resReq, struct resVal *resVal, struct lsInfo *lsInfo, int un
                 default:
                     break;
             }
-            hasFunction = FALSE;
         } else {
             return (PARSE_BAD_EXP);
         }

--- a/lsf/lib/Makefile.am
+++ b/lsf/lib/Makefile.am
@@ -1,7 +1,7 @@
 #
 # Copyright (C) 2011 David Bigagli
 #
-INCLUDES = -I../
+AM_CPPFLAGS = -I../
 
 lib_LIBRARIES = liblsf.a
 

--- a/lsf/lim/Makefile.am
+++ b/lsf/lim/Makefile.am
@@ -1,8 +1,7 @@
 #
 # Copyright (C) openlava foundation
 #
-INCLUDES = -I$(top_srcdir)/lsf
-AM_CPPFLAGS = -D$(HOSTTYPE) -DHOST_TYPE_STRING=\"$(HOSTTYPE)\"
+AM_CPPFLAGS = -I$(top_srcdir)/lsf -D$(HOSTTYPE) -DHOST_TYPE_STRING=\"$(HOSTTYPE)\"
 
 HOSTTYPE=LINUX64
 

--- a/lsf/lim/lim.h
+++ b/lsf/lim/lim.h
@@ -199,8 +199,8 @@ struct liStruct {
     float satvalue;
     float value;
 };
-int li_len;
-struct liStruct *li;
+extern int li_len;
+extern struct liStruct *li;
 
 #define  SEND_NO_INFO       0x00
 #define  SEND_CONF_INFO     0x01

--- a/lsf/lim/lim.main.c
+++ b/lsf/lim/lim.main.c
@@ -117,6 +117,9 @@ usage(void)
 lim: [-C] [-V] [-h] [-t] [-debug_level] [-d env_dir]\n");
 }
 
+int li_len = 0;
+struct liStruct *li = NULL;
+
 /* LIM main()
  */
 int

--- a/lsf/lsadm/Makefile.am
+++ b/lsf/lsadm/Makefile.am
@@ -1,7 +1,7 @@
 #
 # Copyright (C) openlava foundation
 #
-INCLUDES = -I$(top_srcdir)/lsf
+AM_CPPFLAGS = -I$(top_srcdir)/lsf
 
 bin_PROGRAMS = lsadmin
 

--- a/lsf/lstools/Makefile.am
+++ b/lsf/lstools/Makefile.am
@@ -1,52 +1,49 @@
 #
 # Copyright (C) openlava foundation
 #
-INCLUDES = -I..
+AM_CPPFLAGS = -I..
 
 bin_PROGRAMS = lsacct lseligible lshosts lsid lsinfo lsloadadj \
  		lsload lsmon lsplace lsrcp lsrun lsaddhost lsrmhost
 
-lsacct_SOURCES = lsacct.c  
+lsacct_SOURCES = lsacct.c
 lsacct_LDADD = ../lib/liblsf.a ../intlib/liblsfint.a
 
-lseligible_SOURCES = lseligible.c  
+lseligible_SOURCES = lseligible.c
 lseligible_LDADD = ../lib/liblsf.a ../intlib/liblsfint.a
 
-lshosts_SOURCES = lshosts.c  
+lshosts_SOURCES = lshosts.c
 lshosts_LDADD = ../lib/liblsf.a ../intlib/liblsfint.a
 
-lsid_SOURCES = lsid.c  
+lsid_SOURCES = lsid.c
 lsid_LDADD = ../lib/liblsf.a ../intlib/liblsfint.a
 
-lsinfo_SOURCES = lsinfo.c  
+lsinfo_SOURCES = lsinfo.c
 lsinfo_LDADD = ../lib/liblsf.a ../intlib/liblsfint.a
 
-lsloadadj_SOURCES = lsloadadj.c  
+lsloadadj_SOURCES = lsloadadj.c
 lsloadadj_LDADD = ../lib/liblsf.a ../intlib/liblsfint.a
 
 lsload_SOURCES = lsload.c load.c
 lsload_LDADD = ../lib/liblsf.a ../intlib/liblsfint.a
 
-lsmon_SOURCES = lsmon.c  
+lsmon_SOURCES = lsmon.c
 lsmon_LDADD = load.o ../lib/liblsf.a ../intlib/liblsfint.a -lncurses
 
-lsplace_SOURCES = lsplace.c  
+lsplace_SOURCES = lsplace.c
 lsplace_LDADD = ../lib/liblsf.a ../intlib/liblsfint.a
 
 lsrcp_SOURCES = lsrcp.c
-lsrcp_LDADD = ../lib/liblsf.a ../intlib/liblsfint.a 
-if !CYGWIN
-lsrcp_LDADD += -lnsl
-endif
+lsrcp_LDADD = ../lib/liblsf.a ../intlib/liblsfint.a
 
 lsrun_SOURCES = lsrun.c
-lsrun_LDADD = ../lib/liblsf.a 
+lsrun_LDADD = ../lib/liblsf.a
 
 lsaddhost_SOURCES = lsaddhost.c
-lsaddhost_LDADD = ../lib/liblsf.a 
+lsaddhost_LDADD = ../lib/liblsf.a
 
 lsrmhost_SOURCES = lsrmhost.c
-lsrmhost_LDADD = ../lib/liblsf.a 
+lsrmhost_LDADD = ../lib/liblsf.a
 
 etags :
-	etags *.[hc] ../*.h ../lib/*.[hc] 
+	etags *.[hc] ../*.h ../lib/*.[hc]

--- a/lsf/pim/Makefile.am
+++ b/lsf/pim/Makefile.am
@@ -2,7 +2,7 @@
 # Copyright (C) openlava foundation
 #
 
-INCLUDES = -I$(top_srcdir)/lsf
+AM_CPPFLAGS = -I$(top_srcdir)/lsf
 
 sbin_PROGRAMS = pim
 pim_SOURCES  = pim.main.c pim.linux.h

--- a/lsf/res/Makefile.am
+++ b/lsf/res/Makefile.am
@@ -1,16 +1,13 @@
 #
 # Copyright (C) openlava foundation
 #
-INCLUDES = -I$(top_srcdir)/lsf
+AM_CPPFLAGS = -I$(top_srcdir)/lsf
 
 sbin_PROGRAMS = res nios
 res_SOURCES  = \
 res.c res.handler.c res.misc.c res.rf.c res.getproc.c res.init.c \
 res.pty.c res.tasklog.c rescom.h res.h resout.h
 res_LDADD = ../lib/liblsf.a ../intlib/liblsfint.a -lm
-if !CYGWIN
-res_LDADD += -lnsl
-endif
 
 nios_SOURCES = nios.c nios.handler.c nios.h
 #
@@ -18,9 +15,6 @@ nios_SOURCES = nios.c nios.handler.c nios.h
 #
 nios_LDADD = ../../lsbatch/lib/liblsbatch.a \
 	../lib/liblsf.a ../intlib/liblsfint.a -lm
-if !CYGWIN
-nios_LDADD += -lnsl
-endif
 #
 etags:
 	etags *.[hc] ../*.h ../lib/*.[hc] ../intlib/*.[hc]


### PR DESCRIPTION
Fix LIM variable usage from (1994) which is not accepted by modern
compilers anymore. Without those changes LIM does not compile.

 gcc --version
gcc (GCC) 11.4.1 20231218 (Red Hat 11.4.1-3)
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Spago