### PR TITLE
feat: Support application-specific esubs and a defined execution order

### DIFF
--- a/config/lsf.conf.in
+++ b/config/lsf.conf.in
@@ -31,3 +31,6 @@ LSF_PIM_SLEEPTIME_UPDATE=y
 
 LSB_MAX_PACK_JOBS=300
 LSB_PACK_SKIP_ERROR=N
+
+# default esub method list
+# LSB_ESUB_METHOD="example"

--- a/lsf/lib/lib.esub.c
+++ b/lsf/lib/lib.esub.c
@@ -54,8 +54,8 @@ runEsub_(struct lenData *ed, char *path)
 	if (*path == '\0')
 	    strcpy(esub, ESUBNAME);
 	else
-	    sprintf (esub, "%s/%s", path,ESUBNAME);
-	myargv[1] = "-r";
+	    sprintf(esub, "%s", path);
+    myargv[1] = "-r";
  	myargv[2] = NULL;
     }
 


### PR DESCRIPTION
This pull request implements a multi-level `esub` execution framework with the following main enhancements:

### Enhanced -a Option
The functionality of the `-a` option for the `bsub`, `bmod`, and `brestart` commands has been adjusted to accept a space-separated list of application names. For each specified name, volclava will execute a corresponding file named `esub.<app_name>` located in the `LSF_SERVERDIR` directory.

For example, `bsub -a "license fluent" my_job` will trigger the execution of the generic `esub`, any `esub`s configured in `LSB_ESUB_METHOD`, `esub.license`, and `esub.fluent`.

### New lsf.conf Parameter
A new configuration parameter, `LSB_ESUB_METHOD`, has been added to the `lsf.conf` file. This parameter allows administrators to specify a default list of `esub` executables that will be applied to all jobs, enabling the implementation of site-wide submission policies.

### Explicit Execution Order
To ensure predictable and consistent behavior, the system now enforces a strict priority order for all configured `esub` files. The execution order is as follows:
1.  The generic `LSF_SERVERDIR/esub` file.
2.  The `esub` files specified by the `LSB_ESUB_METHOD` parameter in the `lsf.conf` file.
3.  The application-specific `esub` files specified via the command-line `-a` option.

### How to Verify
1.  Create multiple `esub` scripts (e.g., `esub`, `esub.default`, `esub.app1`), each printing a unique identifier to a log file.
2.  Configure `LSB_ESUB_METHOD="default"` in `lsf.conf`.
3.  Submit a job using `bsub -a "app1" <command>`.
4.  Check the log file to confirm that the scripts executed in the correct order: first `esub`, then `esub.default`, and finally `esub.app1`.
5.  Verify that the job modification and rejection functionalities within any of the scripts work as expected.