### PR TITLE
fix: multiple critical bugs and safety improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Congratulates, installation is done and enjoy the journey!
 lim pid: <5922>
 res pid: <5924>
 sbatchd pid: <5927>
-lim mbatchd: <5940>
+mbatchd pid: <5940>
 
 [root@master-test ~]# lsid  ##check cluster status
 volclava project 2.1.1, Nov 11 2025
@@ -139,4 +139,4 @@ The following article offers plentiful user and administrator operation guides, 
 ## Contact Us
 We welcome inquiries and collaboration opportunities regarding the advanced applications of our scheduler, such as developing new features and coming up with new product design. Let's jointly promote the growth of VolcLava. Please feel free to contact us at volclava@picoheart.com
 
-&copy; Copyright (C) 2021-2025 ByteBance Ltd. and/or its affiliates
+&copy; Copyright (C) 2021-2025 ByteDance Ltd. and/or its affiliates

--- a/lsbatch/cmd/bhosts.c
+++ b/lsbatch/cmd/bhosts.c
@@ -584,7 +584,7 @@ prtLoad (struct hostInfoEnt  *hPtrs, struct lsInfo *lsInfo)
     for (i=0; i < last; i++) {
 	loadval[i] = malloc(MAXFIELDSIZE);
 	loadval1[i] = malloc(MAXFIELDSIZE);
-	if (loadval[i] == NULL || loadval[i] == NULL) {
+	if (loadval[i] == NULL || loadval1[i] == NULL) {
 	    lserrno=LSE_MALLOC;
 	    lsb_perror(fname);
 	    exit(-1);

--- a/lsbatch/cmd/cmd.sub.c
+++ b/lsbatch/cmd/cmd.sub.c
@@ -1201,7 +1201,7 @@ prtErrMsg (struct submit *req, struct submitReply *reply)
     case LSBE_JOB_MAX_PEND:
     case LSBE_SLOTS_MAX_PEND:
         if (strlen(reply->pendLimitReason) == 0) {
-            sprintf(tmpBuf, "User <%s>", getenv("USER"));
+            { const char *_u = getenv("USER"); sprintf(tmpBuf, "User <%s>", _u ? _u : "unknown"); }
             sub_perror (tmpBuf);
         } else {
             sub_perror (reply->pendLimitReason);

--- a/lsbatch/daemons/elock.c
+++ b/lsbatch/daemons/elock.c
@@ -253,6 +253,7 @@ touchElock(void)
         ls_syslog(LOG_ERR, I18N_FUNC_S_D_FAIL_M, fname, "lseek",
                   lockfile,
                   lock_fd);
+        close(lock_fd);
         return(MASTER_FATAL);
     }
     else if ((cc = read(lock_fd, buf, 1)) != 1)
@@ -266,6 +267,7 @@ touchElock(void)
         else
             ls_syslog(LOG_ERR, I18N_FUNC_S_FAIL, fname, "read",
                       lockfile);
+        close(lock_fd);
         return(MASTER_FATAL);
     }
     else if (lseek(lock_fd, 0, SEEK_SET) != 0)
@@ -274,6 +276,7 @@ touchElock(void)
         ls_syslog(LOG_ERR, I18N_FUNC_S_D_FAIL_M, fname, "lseek",
                   lockfile,
                   lock_fd);
+        close(lock_fd);
         return(MASTER_FATAL);
     }
     else if ((cc = write(lock_fd, buf, 1)) != 1)
@@ -286,6 +289,7 @@ touchElock(void)
         else
             ls_syslog(LOG_ERR, I18N_FUNC_S_FAIL, fname, "write",
                       lockfile);
+        close(lock_fd);
         return(MASTER_FATAL);
     }
 

--- a/lsbatch/daemons/mbd.requeue.c
+++ b/lsbatch/daemons/mbd.requeue.c
@@ -96,14 +96,16 @@ fill_struct(struct requeueEStruct **rquest, int seqnum, int value, char mode)
 	if ((*rquest)[i].value == value) 
 	    return -1;
     if (seqnum >= numAlloc-1) {
-	numAlloc <<= 1; 
-	if (!(*rquest=(struct requeueEStruct *)
-	    realloc(*rquest, numAlloc*sizeof (struct requeueEStruct)))) {
-	    numAlloc >>= 1; 
-	    return -1;
-	}	
-    }
-    (*rquest)[seqnum].value = value; 
+	int newAlloc = numAlloc << 1;
+	struct requeueEStruct *tmp = (struct requeueEStruct *)
+	    realloc(*rquest, newAlloc*sizeof (struct requeueEStruct));
+		if (!tmp) {
+		    return -1;
+		}
+		*rquest = tmp;
+		numAlloc = newAlloc;
+	    }
+    (*rquest)[seqnum].value = value;
     (*rquest)[seqnum].type = mode;
     (*rquest)[seqnum].interval = 1;
     (*rquest)[seqnum+1].type = RQE_END;   

--- a/lsbatch/daemons/sbd.file.c
+++ b/lsbatch/daemons/sbd.file.c
@@ -1341,7 +1341,7 @@ openStdFiles(char *lsbDir, char *chkpntDir, struct jobCard *jobCardPtr, struct h
             }
 
 
-            jobCardPtr->spooledExec = malloc(strlen(spooledExecName+1));
+            jobCardPtr->spooledExec = malloc(strlen(spooledExecName) + 1);
             if (jobCardPtr->spooledExec != NULL ) {
                 strcpy(jobCardPtr->spooledExec, spooledExecName);
             }
@@ -2233,7 +2233,7 @@ static void saveCreatedPaths(char ***pathList, int *size, char * newPath, int *l
         *pathList = newList;
     }
 
-    (*pathList)[*len] = calloc(strlen(newPath+1), sizeof(char));
+    (*pathList)[*len] = calloc(strlen(newPath) + 1, sizeof(char));
     strcpy((*pathList)[*len], newPath);
     (*len)++;
     return;

--- a/lsf/lib/lib.i18n.c
+++ b/lsf/lib/lib.i18n.c
@@ -132,7 +132,7 @@ _i18n_printf(const char *format, ...)
     va_list ap;
 
     va_start(ap, format);
-    vsprintf(i18nPrintBuffer, format, ap);
+    vsnprintf(i18nPrintBuffer, sizeof(i18nPrintBuffer), format, ap);
     va_end(ap);
     return(i18nPrintBuffer);
 } 

--- a/lsf/lim/lim.main.c
+++ b/lsf/lim/lim.main.c
@@ -1210,6 +1210,7 @@ getClusterConfig(void)
     if (fp == NULL) {
         ls_syslog(LOG_ERR, "\
 %s: popen(%s) failed %m", __func__, buf);
+        return -1;
     }
 
     memset(buf, 0, sizeof(buf));

--- a/lsf/res/res.handler.c
+++ b/lsf/res/res.handler.c
@@ -5958,6 +5958,7 @@ resUpdatetty(struct LSFHeader msgHdr) {
     if (!xdr_resStty(&xdrs, &restty, &msgHdr)) {
         ls_syslog(LOG_ERR, I18N_FUNC_FAIL, fname, "xdr_resStty");
         xdr_destroy(&xdrs);
+        free(tempBuf);
         return(-1);
     }
     xdr_destroy(&xdrs);

--- a/volcuninstall.sh
+++ b/volcuninstall.sh
@@ -19,11 +19,11 @@ while [ $# -gt 0 ]; do
         --env=*)
             VOLC_TOP=$(echo "$1" | awk -F "=" '{print $2}' | sed 's/\/$//')
             if [[ -z $VOLC_TOP ]];then
-                "Error: the value of \"--env\" is empty."
+                echo "Error: the value of \"--env\" is empty."
                 usage
                 exit 1
             fi
-            if [ ! -d $VOLC_TOP ]; then
+            if [ ! -d "$VOLC_TOP" ]; then
                 echo "Error: $VOLC_TOP is not directory."
                 usage
                 exit 1
@@ -48,11 +48,11 @@ if [[ -z "$VOLC_TOP" &&  -z "$LSF_ENVDIR" ]];then
 fi
 
 if [[ -z "$VOLC_TOP" ]];then
-    VOLC_TOP=$(dirname $LSF_ENVDIR)
+    VOLC_TOP=$(dirname "$LSF_ENVDIR")
 fi
 
-if [ -e $LSF_ENVDIR/volclava.sh ]; then
-    MIX_OS_FOLDER=$(grep '^MIX_OS_FOLDER=' $LSF_ENVDIR/volclava.sh  | tail -n 1 | cut -d'=' -f2- | tr -d '"')
+if [ -e "$LSF_ENVDIR/volclava.sh" ]; then
+    MIX_OS_FOLDER=$(grep '^MIX_OS_FOLDER=' "$LSF_ENVDIR/volclava.sh"  | tail -n 1 | cut -d'=' -f2- | tr -d '"')
 else
     echo "Cannot find $LSF_ENVDIR/volclava.sh. We cannot determine the current installation mode, exit..."
     exit 1
@@ -95,10 +95,10 @@ fi
 # Uninstall for installing from source code
 if [[ -n ${MIX_OS_FOLDER} ]]; then
     if [ -d "${BINARY_PATH}" ]; then
-        rm -rf ${BINARY_PATH} || true
+        rm -rf "${BINARY_PATH}" || true
     fi
 else
-    rm -rf ${BINARY_PATH}/bin ${BINARY_PATH}/sbin ${BINARY_PATH}/lib ${VOLC_TOP}/share ${VOLC_TOP}/include || true
+    rm -rf "${BINARY_PATH}/bin" "${BINARY_PATH}/sbin" "${BINARY_PATH}/lib" "${VOLC_TOP}/share" "${VOLC_TOP}/include" || true
 fi
 
 rm -f /etc/init.d/volclava* > /dev/null 2>&1 || true
@@ -108,7 +108,7 @@ systemctl daemon-reload > /dev/null 2>&1 || true
 if [[ -n ${MIX_OS_FOLDER} ]]; then
     DIR_COUNT=$(find "${VOLC_TOP}/${MIX_OS_FOLDER}" -maxdepth 1 -mindepth 1 | wc -l)
     if [ "$DIR_COUNT" -eq 0 ]; then
-        rm -rf "${VOLC_TOP}/${MIX_OS_FOLDER}" "${VOLC_TOP}/share" "${VOLC_TOP}/include" /dev/null 2>&1   || true
+        rm -rf "${VOLC_TOP}/${MIX_OS_FOLDER}" "${VOLC_TOP}/share" "${VOLC_TOP}/include" 2>&1   || true
         echo "Volclava has been successfully uninstalled. Please manually delete the remaining application data."
     else
         echo "Volclava has been successfully uninstalled from the ${PLATFORM} platform."


### PR DESCRIPTION
## Summary
- Fix critical `rm -rf ... /dev/null` bug in volcuninstall.sh that would destroy the system null device
- Fix heap buffer overflow in sbd.file.c caused by `malloc(strlen(ptr+1))` (wrong parenthesization)
- Fix NULL pointer dereference in lim.main.c where `fgets()` was called after `popen()` returned NULL
- Fix duplicate NULL check in bhosts.c (`loadval[i]` checked twice instead of `loadval1[i]`)
- Fix buffer overflow in lib.i18n.c by replacing `vsprintf` with `vsnprintf`
- Fix file descriptor leaks in elock.c on 4 error paths
- Fix memory leak in mbd.requeue.c where `realloc` failure lost the original pointer
- Guard against NULL from `getenv("USER")` in cmd.sub.c
- Fix memory leak in res.handler.c on XDR decode error path
- Fix "ByteBance" typo to "ByteDance" and "lim mbatchd" to "mbatchd pid" in README.md

## Details

### Critical: volcuninstall.sh would destroy /dev/null
Line 111 had `/dev/null` as an argument to `rm -rf`:
```bash
rm -rf "${VOLC_TOP}/${MIX_OS_FOLDER}" "${VOLC_TOP}/share" "${VOLC_TOP}/include" /dev/null 2>&1 || true
```
This would delete `/dev/null` on Linux systems, breaking most programs. Also fixed missing `echo` command on line 22 and unquoted variables in multiple `rm -rf` calls.

### Critical: Heap buffer overflow in sbd.file.c
`malloc(strlen(spooledExecName+1))` computes `strlen` starting one byte *after* the beginning, allocating 2 bytes too few. The subsequent `strcpy` overflows the buffer. Same bug at two locations (lines 1344 and 2236).

### High: NULL pointer dereference in lim.main.c
After `popen()` returns NULL, the code fell through to `fgets(fp, ...)` causing a crash. Added `return -1`.

### High: File descriptor leak in elock.c
`touchElock()` opened a lock file but on 4 different error paths (lseek/read/write failures), returned without closing the file descriptor. In a long-running daemon this would exhaust fd limits.

### Medium: vsprintf buffer overflow in lib.i18n.c
`vsprintf` was used with a fixed 1024-byte buffer with no bounds checking. Replaced with `vsnprintf`.

## Test plan
- [ ] Verify volcuninstall.sh no longer includes `/dev/null` in rm command
- [ ] Verify `echo` command present on error message line
- [ ] Build the project and verify no new warnings introduced
- [ ] Test bhosts command with various host configurations
- [ ] Test bsub error message display with USER env var unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)