### PR TITLE
fix bsub -pack coredump when multi -m in pack files.

### DIFF
--- a/lsbatch/cmd/cmd.sub.c
+++ b/lsbatch/cmd/cmd.sub.c
@@ -359,7 +359,24 @@ LS_LONG_INT do_pack_sub_v2(int option, char **argv, struct submit *req)
         job_requests[job_count]->options = packReq.options;
         job_requests[job_count]->options2 = packReq.options2;
         job_requests[job_count]->numAskedHosts = packReq.numAskedHosts;
-        job_requests[job_count]->askedHosts = packReq.askedHosts;
+        if (packReq.numAskedHosts > 0 && packReq.askedHosts != NULL) {
+            job_requests[job_count]->askedHosts = malloc(packReq.numAskedHosts * sizeof(char *));
+            if (job_requests[job_count]->askedHosts == NULL) {
+                snprintf(outputTmp, sizeof(outputTmp), "Line#%d Memory allocation failed for askedHosts. Job not submitted.\n", lineNum);
+                pack_outputs[packParsedNum-1]->outputMSG = strdup(outputTmp);
+                packParseError++;
+                if (packSkipErrFlag) {
+                    continue;
+                } else {
+                    break;
+                }
+            }
+            for (j = 0; j < packReq.numAskedHosts; j++) {
+                job_requests[job_count]->askedHosts[j] = packReq.askedHosts[j] ? strdup(packReq.askedHosts[j]) : NULL;
+            }
+        } else {
+            job_requests[job_count]->askedHosts = NULL;
+        }
         job_requests[job_count]->rLimits[0] = packReq.rLimits[0];
         job_requests[job_count]->rLimits[1] = packReq.rLimits[1];
         job_requests[job_count]->rLimits[2] = packReq.rLimits[2];
@@ -424,12 +441,9 @@ LS_LONG_INT do_pack_sub_v2(int option, char **argv, struct submit *req)
 
     fclose(fp);
 
-    submitPackRep.numJobs = 0;
-    submitPackRep.numSuccess = 0;
-    submitPackRep.numFailed = 0;
+    memset(&submitPackRep, 0, sizeof(submitPackRep));
 
     if (job_count > 0) {
-        memset(&submitPackRep, 0, sizeof(submitPackRep));
         submitPackRep.submitReps = (struct submitReply *)calloc(job_count, sizeof(struct submitReply));
         if (!submitPackRep.submitReps) {
             fprintf(stderr, "Memory allocation failed\n");

--- a/lsbatch/lib/lsb.xdr.c
+++ b/lsbatch/lib/lsb.xdr.c
@@ -55,8 +55,17 @@ xdr_submitReq (XDR *xdrs, struct submitReq *submitReq, struct LSFHeader *hdr)
 {
 
     int i, nLimits;
-    static int numAskedHosts = 0;
-    static char **askedHosts = NULL;
+
+    if (xdrs->x_op == XDR_FREE) {
+        if (submitReq->numAskedHosts > 0 && submitReq->askedHosts != NULL) {
+            for (i = 0; i < submitReq->numAskedHosts; i++) {
+                FREEUP(submitReq->askedHosts[i]);
+            }
+            FREEUP(submitReq->askedHosts);
+            submitReq->askedHosts = NULL;
+        }
+        submitReq->numAskedHosts = 0;
+    }
 
     if (xdrs->x_op == XDR_DECODE) {
 	submitReq->fromHost[0] = '\0';
@@ -84,12 +93,14 @@ xdr_submitReq (XDR *xdrs, struct submitReq *submitReq, struct LSFHeader *hdr)
 	FREEUP (submitReq->loginShell);
 	FREEUP (submitReq->schedHostType);
 
-	if (numAskedHosts > 0) {
-	    for (i = 0; i < numAskedHosts; i++)
-		FREEUP (askedHosts[i]);
-            FREEUP (askedHosts);
+	/* Clean up existing askedHosts array if it exists */
+	if (submitReq->numAskedHosts > 0 && submitReq->askedHosts != NULL) {
+	    for (i = 0; i < submitReq->numAskedHosts; i++)
+		FREEUP (submitReq->askedHosts[i]);
+            FREEUP (submitReq->askedHosts);
+            submitReq->askedHosts = NULL;
         }
-        numAskedHosts = 0;
+        submitReq->numAskedHosts = 0;
     }
 
 
@@ -196,10 +207,7 @@ xdr_submitReq (XDR *xdrs, struct submitReq *submitReq, struct LSFHeader *hdr)
 	goto Error1;
 
 
-    if (xdrs->x_op == XDR_DECODE) {
-        numAskedHosts = submitReq->numAskedHosts;
-        askedHosts = submitReq->askedHosts;
-    }
+    /* No need to track askedHosts with static variables */
 
 
     if (!xdr_int(xdrs, &submitReq->options2))


### PR DESCRIPTION
This commit fixes two coredump issues in bsub -pack functionality:

1. Server-side coredump when job file contains -m parameter
   - Issue: mbatchd coredumped when processing pack submissions with -m
   - Root cause: Static variables numAskedHosts and askedHosts in xdr_submitReq
               caused memory corruption when processing multiple jobs
   - Fix: Remove static variables, directly use submitReq struct fields

2. Client-side coredump when job file contains invalid lines
   - Issue: bsub coredumped when submitting job files with invalid lines
            (e.g., lines with -pack parameter)
   - Root cause: submitPackRep.submitReps pointer was not initialized to NULL,
               causing FREEUP to attempt freeing a garbage pointer
   - Fix: Use memset to fully initialize submitPackRep struct
   - Also remove redundant memset call