### PR TITLE
fix:the size of interactive job working place cannot be resized #74

### DIFF
--- a/lsf/lib/lib.res.c
+++ b/lsf/lib/lib.res.c
@@ -897,6 +897,13 @@ do_rstty2_(int s, int io_fd, int redirect, int async)
 	if (redirect)
 	    tty.termattr.c_lflag &= ~ECHO;
 
+#ifdef TIOCGWINSZ
+	if (ioctl(io_fd, TIOCGWINSZ, (char *)&tty.ws) < 0) {
+	    tty.ws.ws_row = 24;
+	    tty.ws.ws_col = 80;
+	    tty.ws.ws_xpixel = tty.ws.ws_ypixel = 0;
+	}
+#else
 	if ((cp = getenv("LINES")) != NULL)
 	    tty.ws.ws_row = atoi(cp);
 	else
@@ -906,6 +913,7 @@ do_rstty2_(int s, int io_fd, int redirect, int async)
 	else
 	    tty.ws.ws_col = 80;
 	tty.ws.ws_xpixel = tty.ws.ws_ypixel = 0;
+#endif
     }
 
     if (!async) {

--- a/lsf/res/res.handler.c
+++ b/lsf/res/res.handler.c
@@ -3495,6 +3495,12 @@ setptymode(ttyStruct *tts, int slave)
         }
     }
 
+#ifdef TIOCSWINSZ
+    if (ioctl(slave, TIOCSWINSZ, (char *)&tts->ws) < 0) {
+        ls_syslog(LOG_DEBUG, "%s: ioctl TIOCSWINSZ failed: %m", fname);
+    }
+#endif
+
     if (debug > 1)
         ls_syslog(LOG_DEBUG, "setptymode: Leaving");
 
@@ -5928,6 +5934,9 @@ resUpdatetty(struct LSFHeader msgHdr) {
     ttyStruct ttyInfo;
     char *tempBuf;
     int cc;
+#ifdef TIOCSWINSZ
+    int i;
+#endif
 
     if (logclass & LC_TRACE) {
         ls_syslog(LOG_DEBUG, "%s: Entering", fname);
@@ -5967,7 +5976,22 @@ resUpdatetty(struct LSFHeader msgHdr) {
     ttyInfo.attr = restty.termattr;
     ttyInfo.ws = restty.ws;
 
-
+#ifdef TIOCSWINSZ
+    for (i = 0; i < child_cnt; i++) {
+        if (children[i]->stdio != INVALID_FD
+            && (children[i]->rexflag & REXF_USEPTY)) {
+            if (ioctl(children[i]->stdio, TIOCSWINSZ,
+                      (char *)&ttyInfo.ws) < 0) {
+                ls_syslog(LOG_DEBUG,
+                          "%s: ioctl(TIOCSWINSZ) on child %d failed: %m",
+                          fname, children[i]->pid);
+            }
+        }
+        if (children[i]->backClnPtr != NULL) {
+            children[i]->backClnPtr->tty.ws = ttyInfo.ws;
+        }
+    }
+#endif
 
     return 0;
 

--- a/lsf/res/res.init.c
+++ b/lsf/res/res.init.c
@@ -75,7 +75,6 @@ initConn2NIOS(void)
     conn2NIOS.sock.rbuf->bcount = conn2NIOS.sock.wbuf->bcount = 0;
 }
 
-
 void
 init_res(void)
 {
@@ -85,8 +84,6 @@ init_res(void)
     if (logclass & (LC_TRACE | LC_HANG))
         ls_syslog(LOG_DEBUG, "%s: Entering this routine...", fname);
 
-
-
     if (!sbdMode) {
 	if (! debug) {
 
@@ -95,31 +92,15 @@ init_res(void)
 		fflush(stderr);
 		resExit_(1);
 	    }
-
-
-
 	    chdir("/tmp");
 	}
-
-
 
 	if (debug <= 1) {
 
 	    daemonize_();
-
-
-
 	    ls_openlog("res", resParams[LSF_LOGDIR].paramValue, 0,
 		       resParams[LSF_LOG_MASK].paramValue);
-
-
-
 	    umask(0);
-
-
-
-
-
 	    nice(NICE_LEAST);
 	}
     }
@@ -130,16 +111,15 @@ init_res(void)
     }
 
 
+    defaultTty.ws.ws_row = 24;
+    defaultTty.ws.ws_col = 80;
+    defaultTty.ws.ws_xpixel = defaultTty.ws.ws_ypixel = 0;
     if (isatty(0)) {
         tcgetattr(0, &defaultTty.attr);
-
-        defaultTty.ws.ws_row = 24;
-	defaultTty.ws.ws_col = 80;
-        defaultTty.ws.ws_xpixel = defaultTty.ws.ws_ypixel = 0;
-    } else {
-        defaultTty.ws.ws_row = 24;
-	defaultTty.ws.ws_col = 80;
-        defaultTty.ws.ws_xpixel = defaultTty.ws.ws_ypixel = 0;
+#ifdef TIOCGWINSZ
+        /* Try to get actual window size, keep default if fails */
+        ioctl(0, TIOCGWINSZ, (char *)&defaultTty.ws);
+#endif
     }
 
     if (!sbdMode) {


### PR DESCRIPTION
## 问题描述 https://github.com/bytedance/volclava/issues/74
bsub -Is 存在已知缺陷：提交交互式任务时只会固定分配默认终端尺寸 80×24，不会同步传递当前 gnome-terminal 真实窗口宽高；resize 窗口后也不会下发 TIOCSWINSZ 终端尺寸信号，vim/top/less 等依赖终端宽高的工具只会读取80×24,因此只在左上角一小块显示，拖拽窗口完全无效。

## 修复总结
共修改了 3 个文件、4 处代码 ：

### 1. res.handler.c:5976-5991 — resUpdatetty() 添加 TIOCSWINSZ (P0)
问题 ：NIOS 发来的窗口大小更新被接收后丢弃，未应用到子进程 pty，导致 resize 完全无效。
修复 ：遍历 children ，对使用 pty 的子进程通过 ioctl(TIOCSWINSZ) 设置窗口大小，并更新 backClnPtr->tty.ws 。同时添加了变量 int i 声明。

### 2. res.handler.c:3498-3502 — setptymode() 添加 TIOCSWINSZ (P0)
问题 ： childPty() 调用 setptymode() 时只设置了 termios ，初始窗口大小从未写入 pty 从端，导致初始尺寸始终 80×24。
修复 ：在 tcsetattr() 之后添加 ioctl(slave, TIOCSWINSZ, &tts->ws) 。

### 3. lib.res.c:900-916 — do_rstty2_() 使用 TIOCGWINSZ (P1)
问题 ：初始连接时不读取真实终端尺寸，依赖环境变量或硬编码 24×80。
修复 ：优先使用 TIOCGWINSZ ioctl 获取真实窗口大小，失败时回退到环境变量/默认值。

### 4. res.init.c:136-146 — RES 初始化使用 TIOCGWINSZ (P2)
问题 ：RES 启动时即使连接了 tty，也不读取真实终端尺寸。
修复 ：在 isatty(0) 为真时，优先使用 TIOCGWINSZ 获取真实窗口大小。