### PR TITLE
fix: prevent mbatchd core dump when bsub -pack jobs use -f

### DIFF
--- a/lsbatch/lib/lsb.xdr.c
+++ b/lsbatch/lib/lsb.xdr.c
@@ -64,6 +64,10 @@ xdr_submitReq (XDR *xdrs, struct submitReq *submitReq, struct LSFHeader *hdr)
             FREEUP(submitReq->askedHosts);
             submitReq->askedHosts = NULL;
         }
+        if(submitReq->nxf > 0){
+            FREEUP(submitReq->xf);
+        }
+        submitReq->nxf = 0;
         submitReq->numAskedHosts = 0;
     }
 
@@ -1944,7 +1948,12 @@ bool_t
 xdr_xFile(XDR *xdrs, struct xFile *xf, struct LSFHeader *hdr)
 {
     char *sp;
-
+    /*
+    * struct xFile contains no pointer members, so its fields must not be
+    * freed individually. The memory referenced by xf must be freed by its owner.
+    */
+    if(xdrs->x_op == XDR_FREE)
+        return (TRUE);
     if (xdrs->x_op == XDR_DECODE) {
 	xf->subFn[0] = '\0';
 	xf->execFn[0] = '\0';


### PR DESCRIPTION
 ## Summary

  Fix an `mbatchd` core dump triggered by consecutive `bsub -pack` submissions when the
  previous pack contains a job using `-f`.

  ## Root Cause

  During cleanup of the previous pack request, `xdr_submitReq()` calls `xdr_xFile()` with
  `XDR_FREE`.

  However, `struct xFile` contains fixed-size character arrays rather than independently
  allocated pointers. Calling `xdr_string()` with `XDR_FREE` incorrectly frees these internal
  arrays, resulting in an invalid free and causing `mbatchd` to abort.

  ## Changes

  - Skip field-level cleanup in `xdr_xFile()` for `XDR_FREE`.
  - Free the `submitReq->xf` allocation once in `xdr_submitReq()` and reset `submitReq->nxf` after cleanup.