### PR TITLE
fix: incorrect resreq display and unit conversion when LSF_UNIT_FOR_L…

### DIFF
--- a/lsbatch/daemons/mbd.h
+++ b/lsbatch/daemons/mbd.h
@@ -956,7 +956,6 @@ extern int                    debug;
 extern int                    errno;
 extern int                    nextId;
 extern int                    numRemoteJobsInList;
-extern unitTypes              unitForLimits;
 extern int                    packSkipErrFlag;
 extern struct hTab            jobMergedResReqTab;
 extern struct hTab            jobEffeResReqTab;

--- a/lsbatch/daemons/mbd.init.c
+++ b/lsbatch/daemons/mbd.init.c
@@ -825,9 +825,7 @@ addHost(struct hostInfo *lsf,
 
             hPtr->loadSched[i] = thPtr->loadSched[i];
             if (i == MEM || i == SWP || i == TMP) {
-                for (j = 0; j < unitForLimits; j++) {
-                    hPtr->loadSched[i] *=  1024;
-                }
+                hPtr->loadSched[i] = convertUnitToMB(hPtr->loadSched[i]);
             }
         }
 
@@ -836,12 +834,9 @@ addHost(struct hostInfo *lsf,
 
             hPtr->loadStop[i] = thPtr->loadStop[i];
             if (i == MEM || i == SWP || i == TMP) {
-                for (j = 0; j < unitForLimits; j++) {
-                    hPtr->loadStop[i] *=  1024;
-                }
+                hPtr->loadStop[i] = convertUnitToMB(hPtr->loadStop[i]);
             }
         }
-
     }
 
     hPtr->flags |= HOST_UPDATE;
@@ -2632,9 +2627,7 @@ addQData(struct queueConf *queueConf, int mbdInitFlags )
 
                 qPtr->loadSched[j] = queue->loadSched[j];
                 if (j == MEM || j == SWP || j == TMP) {
-                    for (k = 0; k < unitForLimits; k++) {
-                        qPtr->loadSched[j] *=  1024;
-                    }
+                    qPtr->loadSched[j]  = convertUnitToMB(qPtr->loadSched[j]);
                 }
             }
 
@@ -2642,9 +2635,7 @@ addQData(struct queueConf *queueConf, int mbdInitFlags )
 
                 qPtr->loadStop[j] = queue->loadStop[j];
                 if (j == MEM || j == SWP || j == TMP) {
-                    for (k = 0; k < unitForLimits; k++) {
-                        qPtr->loadStop[j] *=  1024;
-                    }
+                    qPtr->loadStop[j]  = convertUnitToMB(qPtr->loadStop[j]);
                 }
             }
         }

--- a/lsbatch/daemons/mbd.job.c
+++ b/lsbatch/daemons/mbd.job.c
@@ -6989,7 +6989,7 @@ checkResReq(char *resReq, int checkOptions)
     if (checkOptions & PARSE_XOR)
         options |= PR_XOR;
 
-    if (parseResReq (resReq, resValPtr, allLsInfo, options, unitForLimits) != PARSE_OK) {
+    if (parseResReq (resReq, resValPtr, allLsInfo, options) != PARSE_OK) {
         goto error;
     }
 

--- a/lsbatch/daemons/mbd.log.c
+++ b/lsbatch/daemons/mbd.log.c
@@ -1261,7 +1261,7 @@ replay_jobEffeResReq(char * resreq) {
             my_calloc(1, sizeof(struct resVal), "replay_jobEffeResReq");
 
         /* Parse the resource requirement string */
-        if (parseResReq(resreq, resValPtr, allLsInfo, (PR_ALL | PR_BATCH), unitForLimits) != PARSE_OK) {
+        if (parseResReq(resreq, resValPtr, allLsInfo, (PR_ALL | PR_BATCH)) != PARSE_OK) {
             freeResVal(resValPtr);
             return NULL;
         }

--- a/lsbatch/daemons/mbd.main.c
+++ b/lsbatch/daemons/mbd.main.c
@@ -114,7 +114,6 @@ struct jData *jDataList[ALLJLIST];
 int    pendJobSlots = 0;
 struct jData *chkJList;
 
-unitTypes unitForLimits = Megabytes;
 int packSkipErrFlag = FALSE;
 
 struct hTab cpuFactors;
@@ -1693,11 +1692,6 @@ initDaemonParams(void)
     if (daemonParams[LSB_PTILE_PACK].paramValue != NULL
         && (strcasecmp(daemonParams[LSB_PTILE_PACK].paramValue, "y") == 0)) {
         setLsbPtilePack(TRUE);
-    }
-
-    if (daemonParams[LSF_UNIT_FOR_LIMITS].paramValue != NULL) {
-        strToUpper_(daemonParams[LSF_UNIT_FOR_LIMITS].paramValue);
-        unitForLimits = setUnitForLimits(daemonParams[LSF_UNIT_FOR_LIMITS].paramValue);
     }
 
     if (daemonParams[LSB_PACK_SKIP_ERROR].paramValue != NULL

--- a/lsbatch/daemons/mbd.resreq.c
+++ b/lsbatch/daemons/mbd.resreq.c
@@ -74,7 +74,7 @@ struct resVal * mergeResReq(struct jData *jp, int options) {
 
         if (options & MERGE_RESREQ_ANY) {
             char defStr[] = "select[type == any] order[r15s:pg]";
-            if ((cc = parseResReq(defStr, merge, allLsInfo, (PR_ALL | PR_BATCH), unitForLimits)) != PARSE_OK) {
+            if ((cc = parseResReq(defStr, merge, allLsInfo, (PR_ALL | PR_BATCH))) != PARSE_OK) {
                 ls_syslog(LOG_ERR, "\
 %s: Failed to create default resource requirement for job <%s>, cc <%d>. %m", __func__, lsb_jobid2str(jp->jobId), cc);
                 lsbFreeResVal(&merge);
@@ -82,7 +82,7 @@ struct resVal * mergeResReq(struct jData *jp, int options) {
             }
         } else {
             char defStr[] = "select[type == local] order[r15s:pg]";
-            if ((cc = parseResReq(defStr, merge, allLsInfo, (PR_ALL | PR_BATCH), unitForLimits)) != PARSE_OK) {
+            if ((cc = parseResReq(defStr, merge, allLsInfo, (PR_ALL | PR_BATCH))) != PARSE_OK) {
                 ls_syslog(LOG_ERR, "\
 %s: Failed to create default resource requirement for job <%s>, cc <%d>. %m", __func__, lsb_jobid2str(jp->jobId), cc);
                 lsbFreeResVal(&merge);
@@ -1195,7 +1195,7 @@ static char * rusage2Str(struct resVal *resVal){
                     "%s%s=%0.2f", 
                     curSize == 0 ? "" : ":",
                     allLsInfo->resTable[i].name,
-                    resVal->val[i]);
+                    (i == MEM || i == SWP || i == TMP) ? convertUnitFromMB(resVal->val[i]) : resVal->val[i]); 
         }
     }
 

--- a/lsbatch/daemons/misc.c
+++ b/lsbatch/daemons/misc.c
@@ -640,7 +640,7 @@ checkThresholdCond (char *resReq, int unitForLimits)
     resValPtr = (struct resVal *)my_malloc (sizeof (struct resVal),
                                 "checkThresholdCond");
     initResVal (resValPtr);
-    if (parseResReq (resReq, resValPtr, allLsInfo, PR_SELECT, unitForLimits)
+    if (parseResReq (resReq, resValPtr, allLsInfo, PR_SELECT)
             != PARSE_OK) {
         lsbFreeResVal (&resValPtr);
         if (logclass & (LC_EXEC) && resReq)

--- a/lsbatch/daemons/sbd.h
+++ b/lsbatch/daemons/sbd.h
@@ -215,7 +215,6 @@ extern float myFactor;
 extern int pgSuspIdleT;
 extern char *env_dir;
 extern time_t bootTime;
-extern unitTypes unitForLimits;
 
 extern struct listEntry *jobQue;
 extern struct jobCard *jobQueHead;

--- a/lsbatch/daemons/sbd.main.c
+++ b/lsbatch/daemons/sbd.main.c
@@ -119,8 +119,6 @@ int lsbJobCpuLimit = -1;
 int lsbJobMemLimit = -1;
 int lsbStdoutDirect = FALSE;
 
-unitTypes unitForLimits = Megabytes;
-
 int sbdLogMask;
 
 
@@ -175,11 +173,6 @@ main (int argc, char **argv)
 	&&(daemonParams[LSB_STDOUT_DIRECT].paramValue[0] == 'y'
            || daemonParams[LSB_STDOUT_DIRECT].paramValue[0] == 'Y' ) ) {
         lsbStdoutDirect = TRUE;
-    }
-
-    if (daemonParams[LSF_UNIT_FOR_LIMITS].paramValue != NULL) {
-        strToUpper_(daemonParams[LSF_UNIT_FOR_LIMITS].paramValue);
-        unitForLimits = setUnitForLimits(daemonParams[LSF_UNIT_FOR_LIMITS].paramValue);
     }
 
     ls_syslog(LOG_WARNING, "\

--- a/lsbatch/lib/lsb.init.c
+++ b/lsbatch/lib/lsb.init.c
@@ -55,7 +55,6 @@ int _lsb_recvtimeout = DEFAULT_API_RECVTIMEOUT;
 int _lsb_fakesetuid = 0;
 
 int lsbMode_ = LSB_MODE_BATCH;
-unitTypes lsbUnitForLimits = Megabytes;
 
 extern int bExceptionTabInit(void);
 extern int mySubUsage_(void *);
@@ -111,11 +110,6 @@ lsb_init (char *appName)
      
     getLogClass_(lsbParams[LSB_DEBUG_CMD].paramValue,
                  lsbParams[LSB_TIME_CMD].paramValue);
-
-    if (lsbParams[LSB_UNIT_FOR_LIMITS].paramValue != NULL) {
-        strToUpper_(lsbParams[LSB_UNIT_FOR_LIMITS].paramValue);
-        lsbUnitForLimits = setUnitForLimits(lsbParams[LSB_UNIT_FOR_LIMITS].paramValue);
-    }
 
     if (bExceptionTabInit()) {
 	lsberrno = LSBE_LSBLIB;

--- a/lsbatch/lib/lsb.sub.c
+++ b/lsbatch/lib/lsb.sub.c
@@ -137,7 +137,6 @@ extern char *lsb_sysmsg (void);
 extern int _lsb_conntimeout;
 
 extern int lsbMode_;
-extern int lsbUnitForLimits;
 
 static char *useracctmap = NULL;
 static struct lenData ed = {0, NULL};
@@ -594,7 +593,7 @@ getCommonParams (struct submit  *jobSubReq, struct submitReq *submitReq,
                 = jobSubReq->rLimits[LSF_RLIMIT_STACK] * 1024;
         }*/
         submitReq->rLimits[LSF_RLIMIT_STACK] = jobSubReq->rLimits[LSF_RLIMIT_STACK];
-        for (m = 0; m <= lsbUnitForLimits; m++) {
+        for (m = 0; m <= unitForLimits; m++) {
             submitReq->rLimits[LSF_RLIMIT_STACK] *= 1024;
             if (submitReq->rLimits[LSF_RLIMIT_STACK] < 0) {
                 lsberrno = LSBE_BAD_RLIMIT;
@@ -611,7 +610,7 @@ getCommonParams (struct submit  *jobSubReq, struct submitReq *submitReq,
                = jobSubReq->rLimits[LSF_RLIMIT_CORE] * 1024;
         }*/
         submitReq->rLimits[LSF_RLIMIT_CORE] = jobSubReq->rLimits[LSF_RLIMIT_CORE];
-        for (m = 0; m <= lsbUnitForLimits; m++) {
+        for (m = 0; m <= unitForLimits; m++) {
             submitReq->rLimits[LSF_RLIMIT_CORE] *= 1024;
             if (submitReq->rLimits[LSF_RLIMIT_CORE] < 0) {
                 lsberrno = LSBE_BAD_RLIMIT;
@@ -628,7 +627,7 @@ getCommonParams (struct submit  *jobSubReq, struct submitReq *submitReq,
                = jobSubReq->rLimits[LSF_RLIMIT_RSS] * 1024;
         }*/
         submitReq->rLimits[LSF_RLIMIT_RSS] = jobSubReq->rLimits[LSF_RLIMIT_RSS];
-        for (m = 0; m <= lsbUnitForLimits; m++) {
+        for (m = 0; m <= unitForLimits; m++) {
             submitReq->rLimits[LSF_RLIMIT_RSS] *= 1024;
             if (submitReq->rLimits[LSF_RLIMIT_RSS] < 0) {
                 lsberrno = LSBE_BAD_RLIMIT;
@@ -645,7 +644,7 @@ getCommonParams (struct submit  *jobSubReq, struct submitReq *submitReq,
                    = jobSubReq->rLimits[LSF_RLIMIT_SWAP] * 1024;
         }*/
         submitReq->rLimits[LSF_RLIMIT_SWAP] = jobSubReq->rLimits[LSF_RLIMIT_SWAP];
-        for (m = 0; m <= lsbUnitForLimits; m++) {
+        for (m = 0; m <= unitForLimits; m++) {
             submitReq->rLimits[LSF_RLIMIT_SWAP] *= 1024;
             if (submitReq->rLimits[LSF_RLIMIT_SWAP] < 0) {
                 lsberrno = LSBE_BAD_RLIMIT;

--- a/lsf/intlib/intlibout.h
+++ b/lsf/intlib/intlibout.h
@@ -89,7 +89,6 @@ extern int getHostAttribNonLim(char *hname, int updateIntvl);
 extern int            parseResReq (char *,
                                    struct resVal *,
                                    struct lsInfo *,
-                                   int,
                                    int);
 extern void           initParse(struct lsInfo *);
 extern int            getResEntry(const char *);

--- a/lsf/intlib/lsftcl.c
+++ b/lsf/intlib/lsftcl.c
@@ -37,6 +37,7 @@ static char                 runTimeDataQueried;
 static int                  numIndx;
 static int                  nRes;
 static struct tclLsInfo     *myTclLsInfo;
+
 /* Arrays holding symbols used in resource requirement
  * expressions.
  */
@@ -63,6 +64,7 @@ numericValue(ClientData clientData,
     int     *indx;
     float   cpuf;
     char    *value;
+    float   divisor = 1.0;
 
     indx = clientData;
 
@@ -73,13 +75,22 @@ numericValue(ClientData clientData,
     resultPtr->type        = TCL_INT;
     runTimeDataQueried     = TRUE;
 
+    /* Host-side MEM/SWP/TMP load indices and maxMem/maxSwap/maxTmp
+     * are in MB. Convert to the unit specified by LSF_UNIT_FOR_LIMITS
+     * so they compare against user-supplied select/rusage values. */
+    if (unitForLimits > 0
+        && (*indx == MEM || *indx == SWP || *indx == TMP
+            || *indx == MAXMEM || *indx == MAXSWAP || *indx == MAXTMP)) {
+        divisor = convertUnitToMB(divisor);
+    }
+
     if (*indx < numIndx) {
 
         resultPtr->type = TCL_DOUBLE;
         if (*indx <= R15M) {
             resultPtr->doubleValue = hPtr->loadIndex[*indx] * cpuf - 1;
         } else {
-            resultPtr->doubleValue = hPtr->loadIndex[*indx];
+            resultPtr->doubleValue = hPtr->loadIndex[*indx] / divisor;
             if (hPtr->loadIndex[*indx] >= (INFINIT_LOAD - 10.0)
                 && hPtr->flag !=  TCL_CHECK_SYNTAX) {
 
@@ -110,15 +121,18 @@ numericValue(ClientData clientData,
 
     } else if (*indx == MAXMEM) {
 
-        resultPtr->intValue = hPtr->maxMem;
+        resultPtr->type = TCL_DOUBLE;
+        resultPtr->doubleValue = hPtr->maxMem / divisor;
 
     } else if (*indx == MAXSWAP) {
 
-     resultPtr->intValue = hPtr->maxSwap;
+        resultPtr->type = TCL_DOUBLE;
+        resultPtr->doubleValue = hPtr->maxSwap / divisor;
 
     } else if (*indx == MAXTMP) {
 
-        resultPtr->intValue = hPtr->maxTmp;
+        resultPtr->type = TCL_DOUBLE;
+        resultPtr->doubleValue = hPtr->maxTmp / divisor;
 
     } else if (*indx == SERVER) {
 

--- a/lsf/intlib/misc.c
+++ b/lsf/intlib/misc.c
@@ -920,31 +920,3 @@ cleanDynDbgEnv(void)
         putEnv("DYN_DBG_LOGFILENAME", "");
     }
 }
-
-void
-displayEnhancementNames(void) {
-}
-
-unitTypes setUnitForLimits(char *unitParamValue) {
-    if (strcasecmp(unitParamValue, UNIT_M) == 0 || strcasecmp(unitParamValue, UNIT_MB) == 0) {
-        return Megabytes;
-    }
-
-    if (strcasecmp(unitParamValue, UNIT_G) == 0 || strcasecmp(unitParamValue, UNIT_GB) == 0) {
-        return Gigabytes;
-    }
-
-    if (strcasecmp(unitParamValue, UNIT_T) == 0 || strcasecmp(unitParamValue, UNIT_TB) == 0) {
-        return Terabytes;
-    }
-
-    if (strcasecmp(unitParamValue, UNIT_P) == 0 || strcasecmp(unitParamValue, UNIT_PB) == 0) {
-        return Petabytes;
-    }
-
-    if (strcasecmp(unitParamValue, UNIT_E) == 0 || strcasecmp(unitParamValue, UNIT_EB) == 0) {
-        return Exabytes;
-    }
-
-    return Megabytes;
-}

--- a/lsf/intlib/resreq.c
+++ b/lsf/intlib/resreq.c
@@ -18,6 +18,7 @@
  */
 
 #include "intlibout.h"
+#include "../lib/lproto.h"
 #include <pthread.h> 
 struct sections {
     char   *select;
@@ -34,7 +35,6 @@ static int parseSelect(char * ,
                        struct resVal *,
                        struct lsInfo *,
                        bool_t,
-                       int,
                        int);
 static int parseOrder(char * ,
                       struct resVal *,
@@ -44,19 +44,16 @@ static int parseFilter(char * ,
                        struct lsInfo *);
 static int parseUsage(char * ,
                       struct resVal *,
-                      struct lsInfo *,
-                      int);
+                      struct lsInfo *);
 static int parseSpan (char *,
                       struct resVal *);
 static int resToClassNew(char * ,
                          struct resVal *,
                          struct lsInfo *,
-                         int,
                          int);
 static int resToClassOld(char * ,
                          struct resVal *,
                          struct lsInfo *,
-                         int,
                          int);
 static int setDefaults(struct resVal *,
                        struct lsInfo *,
@@ -216,8 +213,7 @@ int
 parseResReq(char *resReq,
             struct resVal *resVal,
             struct lsInfo *lsInfo,
-            int options,
-            int unitForLimits)
+            int options)
 {
     static char       fname[] = "parseResReq()";
     int               cc;
@@ -251,8 +247,7 @@ parseResReq(char *resReq,
                                   resVal,
                                   lsInfo,
                                   TRUE,
-                                  options,
-                                  unitForLimits)) != PARSE_OK){
+                                  options)) != PARSE_OK){
                 pthread_mutex_unlock(&parseMutex);
                 return(cc);
             }
@@ -261,8 +256,7 @@ parseResReq(char *resReq,
                                   resVal,
                                   lsInfo,
                                   FALSE,
-                                  options,
-                                  unitForLimits)) != PARSE_OK){
+                                  options)) != PARSE_OK){
                 pthread_mutex_unlock(&parseMutex);
                 return(cc);
         }
@@ -281,8 +275,7 @@ parseResReq(char *resReq,
     if (options & PR_RUSAGE) {
         if ((cc = parseUsage(reqSect.rusage,
                              resVal,
-                             lsInfo,
-                             unitForLimits)) != PARSE_OK){
+                             lsInfo)) != PARSE_OK){
             pthread_mutex_unlock(&parseMutex);
             return(cc);
         }
@@ -438,7 +431,7 @@ parseSection(char *resReq, struct sections *section)
 }
 
 static int
-parseSelect(char *resReq, struct resVal *resVal, struct lsInfo *lsInfo, bool_t parseXor, int options, int unitForLimits)
+parseSelect(char *resReq, struct resVal *resVal, struct lsInfo *lsInfo, bool_t parseXor, int options)
 {
     static char fname[] = "parseSelect";
     int cc;
@@ -509,7 +502,7 @@ parseSelect(char *resReq, struct resVal *resVal, struct lsInfo *lsInfo, bool_t p
                     FREEUP(resReq2);
                     return (PARSE_BAD_MEM);
                 }
-                if ((cc = parseSelect(expr, &tmpResVal, lsInfo, FALSE, options, unitForLimits)) != PARSE_OK) {
+                if ((cc = parseSelect(expr, &tmpResVal, lsInfo, FALSE, options)) != PARSE_OK) {
                     for (i--;i>=0; i--) {
                         FREEUP(resVal->xorExprs[i]);
                     }
@@ -553,28 +546,28 @@ parseSelect(char *resReq, struct resVal *resVal, struct lsInfo *lsInfo, bool_t p
     syntax = getSyntax(resReq);
     switch(syntax) {
         case OLD:
-            if ( (cc =resToClassOld(resReq, resVal, lsInfo, unitForLimits, options)) != PARSE_OK) {
+            if ( (cc =resToClassOld(resReq, resVal, lsInfo, options)) != PARSE_OK) {
                 resVal->selectStr[0] = '\0';
                 FREEUP(resReq2);
                 return(cc);
             }
             break;
         case NEW:
-            if ( (cc =resToClassNew(resReq, resVal, lsInfo, unitForLimits, options)) != PARSE_OK) {
+            if ( (cc =resToClassNew(resReq, resVal, lsInfo, options)) != PARSE_OK) {
                 resVal->selectStr[0] = '\0';
                 FREEUP(resReq2);
                 return (cc);
             }
             break;
         case EITHER:
-            if ((cc =resToClassOld(resReq, resVal, lsInfo, unitForLimits, options)) != PARSE_OK)  {
+            if ((cc =resToClassOld(resReq, resVal, lsInfo, options)) != PARSE_OK)  {
 
                 if (cc == PARSE_BAD_NAME || cc == PARSE_BAD_VAL) {
                     resVal->selectStr[0] = '\0';
                     FREEUP(resReq2);
                     return (cc);
                 }
-                if ( (cc =resToClassNew(resReq, resVal, lsInfo, unitForLimits, options)) != PARSE_OK) {
+                if ( (cc =resToClassNew(resReq, resVal, lsInfo, options)) != PARSE_OK) {
                     resVal->selectStr[0] = '\0';
                     FREEUP(resReq2);
                     return (cc);
@@ -665,9 +658,9 @@ parseFilter(char *filter, struct resVal *resVal, struct lsInfo *lsInfo)
 }
 
 static int
-parseUsage (char *usageReq, struct resVal *resVal, struct lsInfo *lsInfo, int unitForLimits)
+parseUsage (char *usageReq, struct resVal *resVal, struct lsInfo *lsInfo)
 {
-    int i, j, m, entry;
+    int i, m, entry;
     float value;
     char *token;
 
@@ -737,10 +730,7 @@ parseUsage (char *usageReq, struct resVal *resVal, struct lsInfo *lsInfo, int un
 
             // deal with LSF_UNIT_FOR_LIMITS
             if (entry == MEM || entry == SWP || entry == TMP) {
-                for (j = 0; j < unitForLimits; j++) {
-                    resVal->val[entry] = resVal->val[entry] * 1000;
-                    value = value * 1000;
-                }
+                resVal->val[entry] = convertUnitToMB(resVal->val[entry]);
             }
         }
     }
@@ -866,9 +856,9 @@ validValue(char *value, struct lsInfo *lsInfo, int nentry)
 
 static int
 resToClassNew(char *resReq, struct resVal *resVal,
-              struct lsInfo *lsInfo, int unitForLimits, int options)
+              struct lsInfo *lsInfo, int options)
 {
-    int i, j, s, t, len, entry, hasQuote;
+    int i, s, t, len, entry, hasQuote;
     char res[MAXLSFNAMELEN], val[MAXLSFNAMELEN];
     char tmpbuf[MAXLSFNAMELEN * 7];
     char *sp, *op;
@@ -902,14 +892,6 @@ resToClassNew(char *resReq, struct resVal *resVal,
 
         if (IS_DIGIT(resReq[s])){
             sp[t++] = resReq[s++];
-
-            // deal with LSF_UNIT_FOR_LIMITS
-            if (( resReq[s] == '\0' || ! IS_DIGIT(resReq[s]) ) && ( entry == MEM || entry == SWP || entry == TMP )) {
-                for (j = 0; j < unitForLimits * 3 ; j++) {
-                    sp[t++] = '0';
-                }
-            }
-
             continue;
         }
 
@@ -1050,10 +1032,10 @@ resToClassNew(char *resReq, struct resVal *resVal,
 
 static int
 resToClassOld(char *resReq, struct resVal *resVal,
-              struct lsInfo *lsInfo, int unitForLimits,
+              struct lsInfo *lsInfo,
               int options)
 {
-    int i, j, m, entry;
+    int i, m, entry;
     char *token;
     char tmpbuf[MAXLINELEN];
     float value;
@@ -1141,12 +1123,7 @@ resToClassOld(char *resReq, struct resVal *resVal,
                  }
 
             // deal with LSF_UNIT_FOR_LIMITS
-            if (entry == MEM || entry == SWP || entry == TMP) {
-                for (j = 0; j < unitForLimits; j++) {
-                    resVal->val[entry] = resVal->val[entry] * 1000;
-                    value = value * 1000;
-                }
-            }
+            // unit conversion is deferred to evalResReq() numericValue()
 
             if (valueSpecified) {
                 if (lsInfo->resTable[entry].orderType == INCR)

--- a/lsf/lib/lib.esub.c
+++ b/lsf/lib/lib.esub.c
@@ -240,11 +240,11 @@ runEexec_(char *option, int job, struct lenData *eexec, char *path)
 
 
     if (stat(eexecPath, &sbuf) < 0) {
-	    if (logclass & LC_TRACE)
-	        ls_syslog(LOG_DEBUG,
+        if (logclass & LC_TRACE)
+            ls_syslog(LOG_DEBUG,
 		      "%s: Job/task <%d> eexec will not be run, stat(%s) failed: %m", fname, job, eexecPath);
-	        lserrno = LSE_ESUB;
-	        return (-1);
+        lserrno = LSE_ESUB;
+        return (-1);
     }
 
     i = 0;

--- a/lsf/lib/lib.h
+++ b/lsf/lib/lib.h
@@ -102,7 +102,8 @@ typedef enum {
     LSF_INTERACTIVE_STDERR,
     NO_HOSTS_FILE,
     LSB_SHAREDIR, /* we share this with batch system */
-    LSF_NON_PRIVILEGED_PORTS
+    LSF_NON_PRIVILEGED_PORTS,
+    LSF_UNIT_FOR_LIMITS
 } genparams_t;
 
 #define AM_LAST  (!(genParams_[LSF_AM_OPTIONS].paramValue && \

--- a/lsf/lib/lib.initenv.c
+++ b/lsf/lib/lib.initenv.c
@@ -49,6 +49,7 @@ struct config_param genParams_[] =
     {"HOSTS_FILE", NULL},
     {"LSB_SHAREDIR", NULL},
     {"LSF_NON_PRIVILEGED_PORTS", NULL},
+    {"LSF_UNIT_FOR_LIMITS", NULL},
     {NULL, NULL}
 };
 
@@ -56,10 +57,15 @@ char *stripDomains_ = NULL;
 int  errLineNum_ = 0;
 char *lsTmpDir_;
 
+/* Global unit-for-limits setting (LSF_UNIT_FOR_LIMITS from lsf.conf).
+ * Owned by liblsf.a; set by initenv_().
+ * Read by lib and daemons/libs linking liblsf.a. */
+unitTypes unitForLimits = Megabytes;
 
 static int parseLine(char *line, char **keyPtr, char **valuePtr);
 static int matchEnv(char *, struct config_param *);
 static int setConfEnv(char *, char *, struct config_param *);
+static unitTypes getUnitForLimits(char *);
 
 static int
 doEnvParams_(struct config_param *plp)
@@ -169,6 +175,7 @@ initenv_(struct config_param *userEnv, char *pathname)
     }
 
     lsTmpDir_ = getTempDir_();
+    unitForLimits = getUnitForLimits(genParams_[LSF_UNIT_FOR_LIMITS].paramValue);
 
     if (Error)
         return(-1);
@@ -365,3 +372,20 @@ setConfEnv (char *name, char *value, struct config_param *paramList)
     return(1);
 }
 
+static unitTypes
+getUnitForLimits(char *unitParamValue)
+{
+    if (unitParamValue == NULL)
+        return Megabytes;
+    if (strcasecmp(unitParamValue, UNIT_M) == 0 || strcasecmp(unitParamValue, UNIT_MB) == 0)
+        return Megabytes;
+    if (strcasecmp(unitParamValue, UNIT_G) == 0 || strcasecmp(unitParamValue, UNIT_GB) == 0)
+        return Gigabytes;
+    if (strcasecmp(unitParamValue, UNIT_T) == 0 || strcasecmp(unitParamValue, UNIT_TB) == 0)
+        return Terabytes;
+    if (strcasecmp(unitParamValue, UNIT_P) == 0 || strcasecmp(unitParamValue, UNIT_PB) == 0)
+        return Petabytes;
+    if (strcasecmp(unitParamValue, UNIT_E) == 0 || strcasecmp(unitParamValue, UNIT_EB) == 0)
+        return Exabytes;
+    return Megabytes;
+}

--- a/lsf/lib/lib.misc.c
+++ b/lsf/lib/lib.misc.c
@@ -971,3 +971,45 @@ int getNonPrivilegedPorts() {
         return 1;
     }
 }
+
+/********************************************************************************
+ * convertUnitToMB
+ * Description:
+ *     Convert a value from the unit configured via LSF_UNIT_FOR_LIMITS to MB.
+ *
+ * Input:
+ *     value [in]: value in LSF_UNIT_FOR_LIMITS unit
+ *
+ * Return:
+ *     value in MB
+ ********************************************************************************/
+float
+convertUnitToMB(float value)
+{
+    int j;
+    for (j = 0; j < unitForLimits; j++) {
+        value *= 1024;
+    }
+    return value;
+}
+
+/********************************************************************************
+ * convertUnitFromMB
+ * Description:
+ *     Reverse of convertUnitToMB: convert an MB value back to the unit configured.
+ *
+ * Input:
+ *     valueMB [in]: value in MB
+ *
+ * Return:
+ *     value in LSF_UNIT_FOR_LIMITS unit
+ ********************************************************************************/
+float
+convertUnitFromMB(float valueMB)
+{
+    int j;
+    for (j = 0; j < unitForLimits; j++) {
+        valueMB /= 1024;
+    }
+    return valueMB;
+}

--- a/lsf/lib/lproto.h
+++ b/lsf/lib/lproto.h
@@ -195,6 +195,8 @@ extern void inithostsock_(void);
 
 extern int initenv_(struct config_param *, char *);
 extern char *lsTmpDir_;
+extern unitTypes unitForLimits;
+
 extern short getMasterCandidateNoByName_(char *);
 extern char *getMasterCandidateNameByNo_(short);
 extern int getNumMasterCandidates_();
@@ -403,5 +405,7 @@ extern int getOSUserName_(const char *lsfUserName,
                           char *osUserName, unsigned int osUserNameSize);
 extern int getOSUid_(const char *lsfUserName, uid_t *uid);
 extern int getNonPrivilegedPorts();
+extern float convertUnitToMB(float value);
+extern float convertUnitFromMB(float valueMB);
 
 #endif

--- a/lsf/lim/lim.h
+++ b/lsf/lim/lim.h
@@ -390,8 +390,6 @@ extern int isMasterCandidate;
 extern int limConfReady;
 extern int kernelPerm;
 
-extern unitTypes    unitForLimits;
-
 
 
 extern int readShared(void);

--- a/lsf/lim/lim.info.c
+++ b/lsf/lim/lim.info.c
@@ -382,7 +382,7 @@ hostInfoReq(XDR *xdrs,
 
     getTclHostData (&tclHostData, myHostPtr, myHostPtr, TRUE);
     tclHostData.ignDedicatedResource = ignDedicatedResource;
-    cc = parseResReq(hostInfoRequest.resReq, &resVal, &allInfo, propt, unitForLimits);
+    cc = parseResReq(hostInfoRequest.resReq, &resVal, &allInfo, propt);
     if (cc != PARSE_OK
         || evalResReq(resVal.selectStr,
                       &tclHostData,

--- a/lsf/lim/lim.main.c
+++ b/lsf/lim/lim.main.c
@@ -56,8 +56,6 @@ int  numHostResources;
 struct sharedResource **hostResources = NULL;
 u_short lsfSharedCkSum = 0;
 
-unitTypes unitForLimits = Megabytes;
-
 pid_t pimPid = -1;
 static void startPIM(int, char **);
 
@@ -213,11 +211,6 @@ Reading configuration from %s/lsf.conf\n", env_dir);
         lim_debug = atoi(limParams[LSF_LIM_DEBUG].paramValue);
         if (lim_debug <= 0)
             lim_debug = 1;
-    }
-
-    if (limParams[LSF_UNIT_FOR_LIMITS].paramValue != NULL) {
-        strToUpper_(limParams[LSF_UNIT_FOR_LIMITS].paramValue);
-        unitForLimits = setUnitForLimits(limParams[LSF_UNIT_FOR_LIMITS].paramValue);
     }
 
     if (getuid() != 0) {

--- a/lsf/lim/lim.policy.c
+++ b/lsf/lim/lim.policy.c
@@ -131,7 +131,7 @@ placeReq(XDR *xdrs,
         propt |= PR_DEFFROMTYPE;
 
     getTclHostData (&tclHostData, myHostPtr, myHostPtr, TRUE);
-    cc = parseResReq(plReq.resReq, &resVal, &allInfo, propt, unitForLimits);
+    cc = parseResReq(plReq.resReq, &resVal, &allInfo, propt);
     if (cc != PARSE_OK ||
         (returnCode = evalResReq(resVal.selectStr,
                                  &tclHostData,
@@ -1134,7 +1134,7 @@ loadadjReq(XDR *xdrs, struct sockaddr_in *from, struct LSFHeader *reqHdr, int s)
 
     getTclHostData (&tclHostData, myHostPtr, myHostPtr, TRUE);
     tclHostData.ignDedicatedResource = ignDedicatedResource;
-    cc=parseResReq(jobXfer.resReq, &resVal, &allInfo, PR_RUSAGE, unitForLimits);
+    cc=parseResReq(jobXfer.resReq, &resVal, &allInfo, PR_RUSAGE);
     if ((cc != PARSE_OK) ||
         (returnCode = evalResReq(resVal.selectStr, &tclHostData, FALSE)) < 0) {
         if (cc == PARSE_BAD_VAL)
@@ -1213,7 +1213,7 @@ updExtraLoad(struct hostNode **destHostPtr, char *resReq, int numHosts)
     }
     initResVal (&resVal);
 
-    if (parseResReq(resReq, &resVal, &allInfo, PR_RUSAGE, unitForLimits) != PARSE_OK) {
+    if (parseResReq(resReq, &resVal, &allInfo, PR_RUSAGE) != PARSE_OK) {
         ls_syslog(LOG_ERR, I18N_FUNC_S_FAIL, fname, "parseResReq", resReq);
         return;
     }
@@ -1367,7 +1367,7 @@ loadReq(XDR *xdrs, struct sockaddr_in *from, struct LSFHeader *reqHdr, int s)
 
     getTclHostData (&tclHostData, myHostPtr, myHostPtr, TRUE);
     tclHostData.ignDedicatedResource = ignDedicatedResource;
-    cc = parseResReq(ldReq.resReq, &resVal, &allInfo, propt, unitForLimits);
+    cc = parseResReq(ldReq.resReq, &resVal, &allInfo, propt);
     if((cc != PARSE_OK) ||
        (returnCode = evalResReq(resVal.selectStr,
                                 &tclHostData, ldReq.options & DFT_FROMTYPE)) < 0) {
@@ -1638,7 +1638,7 @@ chkResReq(XDR *xdrs, struct sockaddr_in *from, struct LSFHeader *reqHdr)
 
     limReplyCode = LIME_NO_ERR;
     getTclHostData (&tclHostData, myHostPtr, myHostPtr, TRUE);
-    cc = parseResReq(resReq, &resVal, &allInfo, PR_ALL, unitForLimits);
+    cc = parseResReq(resReq, &resVal, &allInfo, PR_ALL);
     if (cc != PARSE_OK ||
         evalResReq(resVal.selectStr, &tclHostData, FALSE) < 0) {
         if (cc == PARSE_BAD_VAL)

--- a/lsf/lsf.h
+++ b/lsf/lsf.h
@@ -979,7 +979,6 @@ extern int ls_rmhost(const char *);
 extern struct lsEventRec  *ls_readeventrec(FILE *);
 extern int ls_writeeventrec(FILE *, struct lsEventRec *);
 extern int freeHostEntryLog(struct hostEntryLog **);
-extern unitTypes setUnitForLimits(char *);
 extern void strToUpper_(char *);
 
 struct extResInfo {


### PR DESCRIPTION
…IMITS is set

- Fix incorrect effective/combined resreq display when LSF_UNIT_FOR_LIMITS changes the unit
- Fix unit conversion to MB: use 1024 instead of 1000
- Refactor LSF_UNIT_FOR_LIMITS-related code to simplify the logic