### PR TITLE
fix: preserve the installer default prefix

### DIFF
--- a/install.conf.example
+++ b/install.conf.example
@@ -1,7 +1,7 @@
 #Specify top directory, installer will install volclava under this directory.
-#If not defined, installer will install volclava under /opt/volclava-version.
-#e.g. /opt/volclava-2.2
-VOLC_PREFIX=/opt/volclava-version
+#If not defined, installer will install volclava under /opt/volclava-2.2.
+#For example:
+#VOLC_PREFIX=/opt/volclava-2.2
 
 #Specify the cluster administrator. If not defined, installer will create
 #volclava user as cluster administrator

--- a/tests/test-install-conf-defaults.sh
+++ b/tests/test-install-conf-defaults.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euo pipefail
+
+REPO_ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+
+unset VOLC_PREFIX
+source "$REPO_ROOT/install.conf.example"
+
+test -z "${VOLC_PREFIX:-}"
+grep -Fq '#VOLC_PREFIX=/opt/volclava-2.2' \
+    "$REPO_ROOT/install.conf.example"


### PR DESCRIPTION
## Problem

`volcinstall.sh` has a valid default prefix of `/opt/volclava-2.2`, but `install.conf.example` actively assigns the placeholder `/opt/volclava-version`. Following the README workflow and sourcing an unedited copy therefore overrides the real default with a literal placeholder directory.

## Changes

- Leave `VOLC_PREFIX` unset by default in `install.conf.example`.
- Keep `/opt/volclava-2.2` as the documented, commented customization example.
- Add a focused test that sources the example and verifies it does not set `VOLC_PREFIX`.

This preserves the existing installer default and does not change the behavior of users who explicitly set `VOLC_PREFIX`.

## Validation

- `bash tests/test-install-conf-defaults.sh`
- `bash -n tests/test-install-conf-defaults.sh`
- `git diff --check`

All checks passed using Git for Windows Bash.

Fixes #85