### PR TITLE
fix: declare missing RPC build dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: volclava
 Section: misc
 Priority: optional
 Maintainer: Mingze Li <limingze.jiayou@bytedance.com>; Guangbo Shu <shuguangbo@bytedance.com>; Nan Qi <qinan.cn@bytedance.com>
-Build-Depends: autoconf, automake, tcl-dev, libncurses-dev
+Build-Depends: autoconf, automake, tcl-dev, libncurses-dev, libtirpc-dev
 Standards-Version: 2.2-0
 Homepage:
 

--- a/spec/volclava.spec
+++ b/spec/volclava.spec
@@ -60,7 +60,10 @@ ExclusiveArch: x86_64
 URL: https://www.bytedance.com/
 Source: %{name}-%{version}.tar.gz
 Buildroot: %{_tmppath}/%{name}-%{version}-buildroot
-BuildRequires: gcc, tcl-devel, ncurses-devel
+BuildRequires: gcc, tcl-devel, ncurses-devel, libtirpc-devel
+%if 0%{?rhel} >= 8
+BuildRequires: libnsl2-devel
+%endif
 Requires: ncurses, tcl
 Requires(pre): /usr/sbin/useradd
 Requires(post): /sbin/chkconfig


### PR DESCRIPTION
Fixes #89.

## Why

`configure.ac` unconditionally requires the libtirpc headers and library, but neither package recipe declared the corresponding development package. A clean build root created from those recipes therefore cannot satisfy the configure checks.

While validating the RPM change in a clean Rocky 8 container, configure advanced past libtirpc and exposed the same metadata drift for the required libnsl check. `volcinstall.sh` already installs `libnsl2-devel` on Rocky, but the RPM spec did not declare it.

## What changed

- Add `libtirpc-dev` to Debian `Build-Depends`.
- Add `libtirpc-devel` to RPM `BuildRequires`.
- Add `libnsl2-devel` for RHEL-family version 8 and newer, while keeping the existing CentOS 6/7 dependency set intact.

## Validation

[Clean-container validation](https://github.com/ZedingZhang/volclava/actions/runs/33351374580) passed in both jobs:

- Ubuntu 20.04: parsed and installed `debian/control` build dependencies, ran `dpkg-checkbuilddeps`, `./bootstrap.sh`, `make -j2`, and `make check`.
- Rocky 8: parsed and installed the spec's `BuildRequires`, then ran `./bootstrap.sh`, `make -j2`, and `make check`.

The validation commit used the exact final contents of `debian/control` and `spec/volclava.spec`; its temporary workflow is intentionally excluded from this PR.
