### PR TITLE
fix: report queue post-job status correctly

### DIFF
--- a/lsbatch/daemons/sbd.job.c
+++ b/lsbatch/daemons/sbd.job.c
@@ -3329,10 +3329,12 @@ runQPost(struct jobCard *jp)
 {
     int i;
     int pid;
+    int waitResult;
     int maxfds;
     char val[MAXLINELEN];
     char *myargv[6];
     sigset_t newmask;
+    LS_WAIT_T status;
 
     if (logclass & LC_TRACE) {
         chuser(batchId);
@@ -3346,7 +3348,7 @@ runQPost(struct jobCard *jp)
     }
 
     if (!jp->jobSpecs.postCmd || jp->jobSpecs.postCmd[0] == '\0')
-        return -1;
+        return 0;
 
     if (jp->jobSpecs.preCmd && jp->jobSpecs.preCmd[0] != '\0') {
 
@@ -3381,13 +3383,37 @@ runQPost(struct jobCard *jp)
     }
 
     if (pid) {
-        if (waitpid(pid, NULL, 0) < 0) {
+        while ((waitResult = waitpid(pid, &status, 0)) < 0
+               && errno == EINTR)
+            ;
+
+        if (waitResult < 0) {
             chuser(batchId);
             ls_syslog(LOG_ERR, "\
-%s: waitpid(%d) failed for qpre for job <%d>: %m",
+%s: waitpid(%d) failed for qpost for job <%d>: %m",
                       __func__, pid, jp->jobSpecs.jobId);
             chuser(jp->jobSpecs.execUid);
+            return -1;
         }
+
+        if (WIFEXITED(status) && WEXITSTATUS(status) == 0)
+            return 0;
+
+        chuser(batchId);
+        if (WIFEXITED(status)) {
+            ls_syslog(LOG_ERR, "\
+%s: queue's post-exec command for job <%d> exited with status <%d>",
+                      __func__, jp->jobSpecs.jobId, WEXITSTATUS(status));
+        } else if (WIFSIGNALED(status)) {
+            ls_syslog(LOG_ERR, "\
+%s: queue's post-exec command for job <%d> terminated by signal <%d>",
+                      __func__, jp->jobSpecs.jobId, WTERMSIG(status));
+        } else {
+            ls_syslog(LOG_ERR, "\
+%s: queue's post-exec command for job <%d> ended with status <%d>",
+                      __func__, jp->jobSpecs.jobId, LS_STATUS(status));
+        }
+        chuser(jp->jobSpecs.execUid);
         return -1;
     }
 


### PR DESCRIPTION
Fixes #92

## Problem

A normally completed job can still show `Post job process failed` in `bhist -l <jobid>`.

## Root Cause

When neither the queue nor the job configures `POST_EXEC`, `mbd.job.c` stores an empty `postCmd`. `finishJob()` still calls `runQPost()`, whose previous implementation returned `-1` for an empty command. This caused the post-job process to exit with a non-zero status, so `jobGone()` set `JOB_STAT_PERR` and `bhist` reported `Post job process failed`.

The existing parent-process path also returned `-1` after waiting, even when the post-exec command exited successfully.

## Changes

- Treat an empty `POST_EXEC` as success.
- Retry `waitpid()` when interrupted by `EINTR`.
- Return success only when the post-exec command exits with status 0.
- Report non-zero exits, signal termination, and wait failures as errors.
- Correct the `qpre` wait error message to `qpost`.

## Validation

- Clean Ubuntu 20.04 container
- `./bootstrap.sh`
- `./configure --prefix=/tmp/volclava-install`
- `make -j2`
- `make check`
- `git diff --check`
- `git apply --check issue-92-fix.patch`

All completed successfully.